### PR TITLE
Collapsible: Update DOM Attributes

### DIFF
--- a/components/views/collapsible-view.js
+++ b/components/views/collapsible-view.js
@@ -14,22 +14,24 @@ define(['backbone', 'underscore'],
             initialize: function (options) {
                 var self = this;
                 self.options = _.defaults(options, {
-                    toggleTextSelector: '.collapsible-toggle-text',
-                    collapsibleSelector: '.collapsible-content'
+                    toggleTextSelector: '.collapsible-toggle',
+                    collapsibleSelector: '.collapsible-target',
+                    isCollapsedClass: 'is-collapsed'
                 });
                 self.render();
             },
 
-            toggleText: function(isVisible) {
+            toggleState: function(isVisible) {
                 var self = this,
                     $textEl = self.$el.find(self.options.toggleTextSelector);
 
                 if (isVisible) {
-                    $textEl.text(self.$el.data('expand-text'));
+                    $textEl.text(self.$el.data('expanded-text'));
                 } else {
-                    $textEl.text(self.$el.data('collapse-text'));
+                    $textEl.text(self.$el.data('collapsed-text'));
                 }
                 $textEl.attr('aria-expanded', isVisible);
+                self.$el.toggleClass(self.options.isCollapsedClass, !isVisible);
             },
 
             render: function () {
@@ -38,7 +40,7 @@ define(['backbone', 'underscore'],
                     $textEl =self.$el.find(self.options.toggleTextSelector);
 
                 // sets the initial state
-                self.toggleText($collapsibleEl.is(':visible'));
+                self.toggleState($collapsibleEl.is(':visible'));
 
                 // clicking on the toggle text will hide/show content and update text
                 $textEl.click(function () {
@@ -46,7 +48,7 @@ define(['backbone', 'underscore'],
                     // in transition
                     var isVisible = $collapsibleEl.is(':visible');
                     $collapsibleEl.slideToggle();
-                    self.toggleText(!isVisible);
+                    self.toggleState(!isVisible);
                 });
 
                 return self;

--- a/test/specs/components/views/collapsible-view-spec.js
+++ b/test/specs/components/views/collapsible-view-spec.js
@@ -15,13 +15,13 @@ define(['jquery', 'components/views/collapsible-view'], function ($, Collapsible
             spyOn($.fn, 'slideToggle');
 
             // set up the text to display
-            collapsibleEl.setAttribute('data-expand-text', 'Expand Text');
-            collapsibleEl.setAttribute('data-collapse-text', 'Click to Collapse');
+            collapsibleEl.setAttribute('data-expanded-text', 'Expand Text');
+            collapsibleEl.setAttribute('data-collapsed-text', 'Click to Collapse');
 
-            toggleText.className = 'collapsible-toggle-text';
+            toggleText.className = 'collapsible-toggle';
             collapsibleEl.appendChild(toggleText);
 
-            toggleContent.className = 'collapsible-content';
+            toggleContent.className = 'collapsible-target';
             toggleContent.textContent = 'sample stuff';
             collapsibleEl.appendChild(toggleContent);
 
@@ -31,6 +31,7 @@ define(['jquery', 'components/views/collapsible-view'], function ($, Collapsible
             expect(toggleText.textContent).toEqual('Click to Collapse');
             expect($.fn.slideToggle).not.toHaveBeenCalled();
             expect(toggleText.getAttribute('aria-expanded')).toBe('false');
+            expect($(collapsibleEl).hasClass('is-collapsed')).toBe(true);
 
             $(toggleText).trigger('click');
             expect(toggleText.textContent).toEqual('Expand Text');
@@ -38,6 +39,7 @@ define(['jquery', 'components/views/collapsible-view'], function ($, Collapsible
             // should have been called
             expect($.fn.slideToggle).toHaveBeenCalled();
             expect(toggleText.getAttribute('aria-expanded')).toBe('true');
+            expect($(collapsibleEl).hasClass('is-collapsed')).toBe(false);
         });
 
     });


### PR DESCRIPTION
Per the conversations with @dsjen, @cptvitamin , and @AlasdairSwan , this work updates collapsible stateful and structural DOM attributes of the Collapsible Component.

- - - 

TODOs in a separate line of work still include:

* defining a ``.collapsible-container`` DOM element that contains directly or indirectly the other DOM elements already defined
* toggling a class of ``is-collapsed`` on the ``collapsible-container`` element.

- - -

##### Reviewers

* [ ] @dsjen and @AlasdairSwan 