### PR TITLE
Fix recent travis failures

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -44,7 +44,6 @@
     "expr"          : false,       // Suppresses warnings about the use of expressions where normally you would expect to see assignments or function calls.
     "funcscope"     : false,       // Suppresses warnings about declaring variables inside of control structures while accessing them later from the outside.
     "gcl"           : false,       // Makes JSHint compatible with Google Closure Compiler.
-    "globalstrict"  : false,       // Suppresses warnings about the use of global strict mode.
     "iterator"      : false,       // Suppresses warnings about the __iterator__ property.
     "lastsemic"     : false,       // Suppresses warnings about missing semicolons, but only when the semicolon is omitted for the last statement in a one-line block.
     "laxbreak"      : false,       // Suppresses most of the warnings about possibly unsafe line breaks in your code.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: node_js
+
 sudo: false
+
+node_js:
+    - "4.1"
 
 install:
     - npm install
     - bower install
+
 script: gulp
 
 branches:


### PR DESCRIPTION
This should fix the build errors seen in https://github.com/edx/edx-ui-toolkit/pull/13

Background:
I fixed this same bug - in a different way - in Insights [last week](https://github.com/edx/edx-analytics-dashboard/pull/388). Our travis' version of `node`, and consequentially it's versions of `npm` and `semver`, is out of date. The old version of `semver` is permitting prerelease-taged packages to satisfy version requirements, which is why `jshint` 2.9.1-rc1 is getting installed. That version of `jshint` adds backwards-incompatible changes restricting the way that the `'strict'` and `'globalstrict'` options are used. Hence our builds fail. This fixes both the issue with `node` as well as the one with `jshint`.

@benpatterson @andy-armstrong @dsjen 