### PR TITLE
Correctly merges 'queryParams'/'state' in 'extend'

### DIFF
--- a/components/pagination/collections/paging_collection.js
+++ b/components/pagination/collections/paging_collection.js
@@ -35,28 +35,24 @@
             searchString: '',
             filterableFields: {},
 
+            state: {
+                firstPage: 1,
+                pageSize: 10,
+                sortKey: null
+            },
+
+            queryParams: {
+                currentPage: 'page',
+                pageSize: 'page_size',
+                sortKey: 'order_by',
+                order: 'sort_order',
+                text_search: function () { return this.searchString || null; }
+            },
+
             constructor: function (models, options) {
-                var defaultOptions = {
-                    state: {
-                        firstPage: 1,
-                        pageSize: 10,
-                        sortKey: null
-                    },
-                    queryParams: {
-                        currentPage: 'page',
-                        pageSize: 'page_size',
-                        sortKey: 'order_by',
-                        order: 'sort_order',
-                        text_search: function () { return this.searchString || null; }
-                    }
-                };
-
-                if (_.isUndefined(options)) { options = {}; }
-                _.extend(defaultOptions, _.omit(options, 'state', 'queryParams'));
-                _.extend(defaultOptions.state, options.state);
-                _.extend(defaultOptions.queryParams, options.queryParams);
-
-                PageableCollection.prototype.constructor.call(this, models, defaultOptions);
+                this.state = _.extend({}, PagingCollection.prototype.state, this.state);
+                this.queryParams = _.extend({}, PagingCollection.prototype.queryParams, this.queryParams);
+                PageableCollection.prototype.constructor.call(this, models, options);
             },
 
             initialize: function (models, options) {
@@ -377,6 +373,7 @@
                 }
             }
         });
+
         return PagingCollection;
     });
 }).call(this, define || RequireJS.define);

--- a/test/specs/components/pagination/paging_collection_spec.js
+++ b/test/specs/components/pagination/paging_collection_spec.js
@@ -46,10 +46,23 @@ define(['jquery',
             };
 
             beforeEach(function () {
-                collection = new PagingCollection([], {state: {perPage: 10}});
+                collection = new PagingCollection([], {state: {pageSize: 10}});
                 collection.url = '/test';
                 server.isZeroIndexed = false;
                 server.count = 43;
+            });
+
+            it('correctly merges state and queryParams in the extend statement', function () {
+                var MyPagingCollection, newCollection;
+                MyPagingCollection = PagingCollection.extend({
+                    state: {pageSize: 25},
+                    queryParams: {pageSize: 'per_page'}
+                });
+                newCollection = new MyPagingCollection([]);
+                expect(newCollection.state.pageSize).toBe(25);
+                expect(newCollection.state.firstPage).toBe(1);
+                expect(newCollection.queryParams.pageSize).toBe('per_page');
+                expect(newCollection.queryParams.currentPage).toBe('page');
             });
 
             it('can register sortable fields', function () {
@@ -206,7 +219,7 @@ define(['jquery',
             }));
 
             it('has instance-unique filterableFields and sortablefields', function () {
-                var otherCollection = new PagingCollection([], {state: {perPage: 10}});
+                var otherCollection = new PagingCollection([], {state: {pageSize: 10}});
                 collection.registerFilterableField('foo', 'foo');
                 collection.setFilterField('foo', 'bar');
                 collection.registerSortableField('quux', 'quux');


### PR DESCRIPTION
I was improperly handling the way that `backbone.paginator` expects the `state` and `queryParams` properties to be set when overriding with the `extend` function. This change allows child classes to override those properties (recursively) by simply specifying them in the object passed to `extend`, as expected.

@andy-armstrong @AlasdairSwan please review