### PR TITLE
Add `getActiveFilterFields` method to `PagingCollection`

### DIFF
--- a/src/js/pagination/paging-collection.js
+++ b/src/js/pagination/paging-collection.js
@@ -302,6 +302,17 @@
             },
 
             /**
+             * Gets an array of currently active (applied) filters.
+             * @returns {Array} An array of filter field names which are
+             *     currently applied to the collection.
+             */
+            getActiveFilterFields: function () {
+                return _.chain(this.filterableFields).pick(function (fieldData, fieldName) {
+                    return !_.isNull(fieldData.value) && !_.isUndefined(fieldData.value);
+                }).keys().value();
+            },
+
+            /**
              * Sets a filter field to a given value and marks the
              * collection as stale.
              * @param fieldName querystring parameter name for the

--- a/src/js/pagination/specs/paging-collection-spec.js
+++ b/src/js/pagination/specs/paging-collection-spec.js
@@ -144,6 +144,15 @@ define(['jquery',
                 expect('test_field_2' in getUrlParams(requests[requests.length - 1])).not.toBe(true);
             }));
 
+            it('can return the currently active filter fields', function () {
+                collection.registerFilterableField('test_field_1', 'Test Field 1');
+                collection.registerFilterableField('test_field_2', 'Test Field 2');
+                collection.registerFilterableField('test_field_3', 'Test Field 3');
+                collection.setFilterField('test_field_1', 'test_value_1');
+                collection.setFilterField('test_field_3', 'test_value_3');
+                expect(collection.getActiveFilterFields()).toEqual(['test_field_1', 'test_field_3']);
+            });
+
             it('can set the sort direction', AjaxHelpers.requests(
                 function (requests) {
                     collection.setSortField('test_field');


### PR DESCRIPTION
@andy-armstrong mind giving this a review? I added a method to the paging collection to return an array of the currently active filters, which will be useful for Learner Analytics.