### PR TITLE
Added image and placeholder logic to user anchor element

### DIFF
--- a/src/js/dropdown-menu/dropdown-menu-view.js
+++ b/src/js/dropdown-menu/dropdown-menu-view.js
@@ -15,6 +15,8 @@ define([
          *  className: 'space separated string of classes for element',
          *  model: with the following attributes (example values added)
          *      main: {
+         *          image: 'http://placehold.it/40x40'',
+         *          screenreader_label: 'Dashboard for: ',
          *          text: 'username',
          *          url: 'dashboard'
          *      },
@@ -82,7 +84,7 @@ define([
                  *  Example code:
                  *
                  *  var $link = $(event.target),
-                 *      label = $link.hasClass('user-title') ? 'Dashboard' : $link.html().trim();
+                 *      label = $link.hasClass('menu-title') ? 'Dashboard' : $link.html().trim();
                  *
                  *  window.analytics.track('user_dropdown.clicked', {
                  *      category: 'navigation',

--- a/src/js/dropdown-menu/dropdown.underscore
+++ b/src/js/dropdown-menu/dropdown.underscore
@@ -1,8 +1,14 @@
-<a href="<%- main.url %>" class="user-title">
-    <span class="sr"><%- main.screenreader_label %> </span><%- main.text %>
+<a href="<%- main.url %>" class="menu-title">
+    <% if (main.screenreader_label) { %>
+        <span class="sr-only"><%- main.screenreader_label %> </span>
+    <% } %>
+    <% if (main.image) { %>
+        <img class="menu-image" src="<%- main.image %>" alt="">
+    <% } %>
+    <%- main.text %>
 </a>
 <button type="button" class="button button-more has-dropdown js-dropdown-button" aria-haspopup="true" aria-expanded="false" aria-controls="edx-user-menu">
-    <span class="sr"><%- button_label %></span>
+    <span class="sr-only"><%- button_label %></span>
 </button>
 <ul class="dropdown-menu is-hidden" id="edx-user-menu" tabindex="-1">
     <% _.each(items, function(item, index) { %>

--- a/src/js/dropdown-menu/specs/dropdown-menu-view-spec.js
+++ b/src/js/dropdown-menu/specs/dropdown-menu-view-spec.js
@@ -22,7 +22,7 @@ define([
                 var ExtendedDropdownMenuView = DropdownMenuView.extend({
                     analyticsLinkClick: function(event) {
                         var $link = $(event.target),
-                            label = $link.hasClass('user-title') ? 'Dashboard' : $link.html().trim();
+                            label = $link.hasClass('menu-title') ? 'Dashboard' : $link.html().trim();
 
                         /**
                          *  Add your own analytics tracking here
@@ -130,8 +130,45 @@ define([
                 jasmine.clock().tick(201);
             });
 
+            it('should add a screenreader label to the user link if provided', function() {
+                var $srLabel = view.$el.find('.menu-title .sr-only'),
+                    srLabelText = 'Dashboard for:';
+
+                expect($srLabel.length).toEqual(0);
+
+                view.model.set({
+                    main: {
+                        text: 'username',
+                        screenreader_label: srLabelText,
+                        url: 'dashboard'
+                    }
+                });
+                view.render();
+                $srLabel = view.$el.find('.menu-title .sr-only');
+                expect($srLabel.length).toEqual(1);
+                expect($srLabel.html().trim()).toEqual(srLabelText);
+            });
+
+            it('should add a user image to the user link if provided', function() {
+                var $img = view.$el.find('.menu-title .menu-image'),
+                    imgSrc = 'http://placehold.it/350x150';
+                expect($img.length).toEqual(0);
+
+                view.model.set({
+                    main: {
+                        text: 'username',
+                        image: imgSrc,
+                        url: 'dashboard'
+                    }
+                });
+                view.render();
+                $img = view.$el.find('.menu-title .menu-image');
+                expect($img.length).toEqual(1);
+                expect($img.attr('src')).toEqual(imgSrc);
+            });
+
             it('should open track analytics for user title clicks', function() {
-                var $userTitle = view.$el.find('.user-title'),
+                var $userTitle = view.$el.find('.menu-title'),
                     analyticsData = {
                         category: 'navigation',
                         label: 'Dashboard',


### PR DESCRIPTION
@andy-armstrong @dan-f this change updates the dropdown menu to add the ability to include a user image in the link (like lms does) and also cleans up the screenreader_label logic.