### PR TITLE
Implement HtmlUtils helper functions

### DIFF
--- a/src/js/utils/html-utils.js
+++ b/src/js/utils/html-utils.js
@@ -1,0 +1,145 @@
+/**
+ * Useful functions for dealing with HTML.
+ *
+ * In particular, these functions default to being safe against
+ * Cross Site Scripting (XSS) attacks.
+ */
+(function(define) {
+    'use strict';
+    define(['underscore', './string-utils.js'], function(_, StringUtils) {
+        var escape, interpolateHtml, HTML, template;
+
+        /**
+         * Creates an HTML snippet.
+         *
+         * The intention of an HTML snippet is to capture a string that
+         * is known to contain HTML that has been safely escaped.
+         * As an example, this allows interpolate to understand that
+         * it does not need to further escape this HTML.
+         *
+         * @param {string} htmlString The string of HTML.
+         * @constructor
+         */
+        function HtmlSnippet(htmlString) {
+            this.text = htmlString;
+        }
+        HtmlSnippet.prototype.valueOf = function() {
+            return this.text;
+        };
+        HtmlSnippet.prototype.toString = function() {
+            return this.text;
+        };
+
+        /**
+         * Helper function to create an HTML snippet.
+         *
+         * @param {string} htmlString The string of HTML.
+         * @returns {HtmlSnippet} An HTML snippet that can be safely rendered.
+         * @constructor
+         */
+        HTML = function(htmlString) {
+            return new HtmlSnippet(htmlString);
+        };
+
+        /**
+         * Returns HTML that is appropriately escaped.
+         *
+         * If the input is provided as a string, then an HtmlSnippet
+         * is returned with the original text escaped. If the input
+         * is already an HtmlSnippet then it is known to be already
+         * escaped and so it is just returned directly.
+         *
+         * @param {(string|HtmlSnippet)} text Some HTML that is
+         * either provided as a string or as an HtmlSnippet.
+         * @returns {HtmlSnippet} A safely escaped HtmlSnippet.
+         */
+        escape = function(text) {
+            if (text instanceof HtmlSnippet) {
+                return text;
+            } else {
+                return HTML(_.escape(text));
+            }
+        };
+
+        /**
+         * Returns an HTML snippet by interpolating the provided parameters.
+         *
+         * The HTML text is provided as a tokenized format string where parameters
+         * are indicated via curly braces, e.g. 'Hello {name}'. These tokens are
+         * replaced by the parameter value of the same name.
+         *
+         * Parameter values will be rendered using their toString methods and then
+         * HTML-escaped. The only exception is that instances of the class HTML
+         * are rendered without escaping as their contract declares that they are
+         * already valid HTML.
+         *
+         * Example:
+         *   HtmlUtils.interpolateHtml(
+         *       'You are enrolling in {spanStart}{courseName}{spanEnd}',
+         *       {
+         *           courseName: 'Rock & Roll 101',
+         *           spanStart: HtmlUtils.HTML('<span class="course-title">'),
+         *           spanEnd: HtmlUtils.HTML('</span>')
+         *       }
+         *   );
+         *
+         * returns:
+         *   'You are enrolling in <span class="course-title">Rock &amp; Roll 101</span>'
+         *
+         * Note: typically the formatString will need to be internationalized, in which
+         * case it will be wrapped with a call to an i18n lookup function. In Django,
+         * this would look like:
+         *
+         *   HtmlUtils.interpolateHtml(
+         *       gettext('You are enrolling in {spanStart}{courseName}{spanEnd}'),
+         *       ...
+         *   );
+         *
+         * @param {string} formatString The string to be interpolated.
+         * @param {Object} parameters An optional set of parameters to the template.
+         * @returns {HtmlSnippet} The resulting safely escaped HTML snippet.
+         */
+        interpolateHtml = function(formatString, parameters) {
+            var result = StringUtils.interpolate(
+                escape(formatString).toString(),
+                _.mapObject(parameters, escape)
+            );
+            return HTML(result);
+        };
+
+        /**
+         * Returns a function that renders an Underscore template as an HTML snippet.
+         *
+         * Note: This helper function makes the following context parameters
+         * available to the template in addition to those passed in:
+         *
+         *   * HtmlUtils: the HtmlUtils helper class
+         *
+         * @param {string} text
+         * @param {object} settings
+         * @returns {function} A function that returns a rendered HTML snippet.
+         */
+        template = function(text, settings) {
+            var HtmlUtils = this,
+                rawTemplate = _.template(text, settings),
+                template = function(data) {
+                    var augmentedData = _.extend(
+                        {
+                            HtmlUtils: HtmlUtils
+                        },
+                        data
+                    );
+                    return HTML(rawTemplate(augmentedData));
+                };
+            return template;
+        };
+
+        return {
+            escape: escape,
+            HTML: HTML,
+            HtmlSnippet: HtmlSnippet,
+            interpolateHtml: interpolateHtml,
+            template: template
+        };
+    });
+}).call(this, define || RequireJS.define);

--- a/src/js/utils/specs/html-utils-spec.js
+++ b/src/js/utils/specs/html-utils-spec.js
@@ -1,0 +1,108 @@
+define(
+    [
+        '../../utils/spec-helpers/spec-helpers.js',
+        '../html-utils.js'
+    ],
+    function(SpecHelpers, HtmlUtils) {
+        'use strict';
+
+        describe('HtmlUtils', function() {
+            describe('HtmlSnippet', function() {
+                it('can convert to a string', function() {
+                    expect(new HtmlUtils.HtmlSnippet('Hello, world').toString()).toBe('Hello, world');
+                });
+            });
+
+            describe('HTML', function() {
+                it('returns an HtmlSnippet', function() {
+                    expect(HtmlUtils.HTML('Hello, world') instanceof HtmlUtils.HtmlSnippet).toBeTruthy();
+                });
+            });
+
+            describe('escape', function() {
+                SpecHelpers.withData({
+                    'HTML escapes text strings': [
+                        'Rock & Roll',
+                        'Rock &amp; Roll'
+                    ],
+                    'HTML escapes full HTML strings': [
+                        '<a href="world">Rock &amp; Roll</a>',
+                        '&lt;a href=&quot;world&quot;&gt;Rock &amp;amp; Roll&lt;/a&gt;'
+                    ],
+                    'does not escape HTML snippets': [
+                        HtmlUtils.HTML('<a href="world">Rock &amp; Roll</a>'),
+                        '<a href="world">Rock &amp; Roll</a>'
+                    ]
+                }, function(input, expectedString) {
+                    var result = HtmlUtils.escape(input);
+                    expect(result.toString()).toBe(expectedString);
+                });
+            });
+
+            describe('interpolateHtml', function() {
+                it('can interpolate a string with no parameters provided', function() {
+                    expect(HtmlUtils.interpolateHtml('Hello, world').toString()).toBe(
+                        'Hello, world'
+                    );
+                });
+
+                SpecHelpers.withData({
+                    'can interpolate a string with empty parameters': [
+                        'Hello, world', {},
+                        'Hello, world'
+                    ],
+                    'can interpolate a string with one parameter': [
+                        'Hello, {name}', {name: 'Andy'},
+                        'Hello, Andy'
+                    ],
+                    'does not interpolate additional curly braces': [
+                        'Hello, {name}. Here is a { followed by a }', {name: 'Andy'},
+                        'Hello, Andy. Here is a { followed by a }'
+                    ],
+                    'escapes characters in the template': [
+                        'Rock & Roll', {},
+                        'Rock &amp; Roll'
+                    ],
+                    'does not escape HTML parameters': [
+                        'Hello, {anchor}', {anchor: HtmlUtils.HTML('<a href="world">world</a>')},
+                        'Hello, <a href="world">world</a>'
+                    ],
+                    'escapes characters in parameters': [
+                        'I love {name}', {name: 'Rock & Roll'},
+                        'I love Rock &amp; Roll'
+                    ],
+                    'does not double escape when chaining interpolate calls': [
+                        'I love {name}', {name: HtmlUtils.interpolateHtml('Rock & Roll')},
+                        'I love Rock &amp; Roll'
+                    ],
+                    'full example': [
+                        'You are enrolling in {spanStart}{courseName}{spanEnd}',
+                        {
+                            courseName: 'Rock & Roll',
+                            spanStart: HtmlUtils.HTML('<span class="course-title">'),
+                            spanEnd: HtmlUtils.HTML('</span>')
+                        },
+                        'You are enrolling in <span class="course-title">Rock &amp; Roll</span>'
+                    ]
+                }, function(template, options, expectedString) {
+                    var result = HtmlUtils.interpolateHtml(template, options);
+                    expect(result.toString()).toBe(expectedString);
+                });
+            });
+
+            describe('template', function() {
+                it('returns a template that renders correctly', function() {
+                    var template = HtmlUtils.template('Hello, <%- name %>'),
+                        result = template({name: 'world'});
+                    expect(result instanceof HtmlUtils.HtmlSnippet).toBeTruthy();
+                    expect(result.toString()).toBe('Hello, world');
+                });
+
+                it('adds HtmlView as an additional context variable for the template', function() {
+                    var template = HtmlUtils.template('I love <%= HtmlUtils.escape("Rock & Roll") %>');
+                    expect(template().toString()).toBe('I love Rock &amp; Roll');
+                });
+            });
+        });
+    }
+);

--- a/src/js/utils/specs/string-utils-spec.js
+++ b/src/js/utils/specs/string-utils-spec.js
@@ -1,0 +1,37 @@
+define(
+    [
+        '../../utils/spec-helpers/spec-helpers.js',
+        '../string-utils.js'
+    ],
+    function(SpecHelpers, StringUtils) {
+        'use strict';
+
+        describe('StringUtils', function() {
+            describe('interpolate', function() {
+                it('can interpolate a string with no parameters provided', function() {
+                    expect(StringUtils.interpolate('Hello, world').toString()).toBe(
+                        'Hello, world'
+                    );
+                });
+
+                SpecHelpers.withData({
+                    'can interpolate a string with empty parameters': [
+                        'Hello, world', {},
+                        'Hello, world'
+                    ],
+                    'can interpolate a string with one parameter': [
+                        'Hello, {name}', {name: 'Andy'},
+                        'Hello, Andy'
+                    ],
+                    'does not interpolate additional curly braces': [
+                        'Hello, {name}. Here is a { followed by a }', {name: 'Andy'},
+                        'Hello, Andy. Here is a { followed by a }'
+                    ]
+                }, function(template, options, expectedString) {
+                    var result = StringUtils.interpolate(template, options);
+                    expect(result.toString()).toBe(expectedString);
+                });
+            });
+        });
+    }
+);

--- a/src/js/utils/string-utils.js
+++ b/src/js/utils/string-utils.js
@@ -1,0 +1,59 @@
+/**
+ * Useful functions for dealing with strings.
+ */
+(function(define) {
+    'use strict';
+    define(['underscore', './string-utils.js'], function(_, StringUtils) {
+        var interpolate;
+
+        /**
+         * Returns a string created by interpolating the provided parameters.
+         *
+         * The HTML text is provided as a tokenized format string where parameters
+         * are indicated via curly braces, e.g. 'Hello {name}'. These tokens are
+         * replaced by the parameter value of the same name.
+         *
+         * Parameter values will be rendered using their toString methods and then
+         * HTML-escaped. The only exception is that instances of the class HTML
+         * are rendered without escaping as their contract declares that they are
+         * already valid HTML.
+         *
+         * Example:
+         *   HtmlUtils.interpolate(
+         *       'You are enrolling in {spanStart}{courseName}{spanEnd}',
+         *       {
+         *           courseName: 'Rock & Roll 101',
+         *           spanStart: HtmlUtils.HTML('<span class="course-title">'),
+         *           spanEnd: HtmlUtils.HTML('</span>')
+         *       }
+         *   );
+         *
+         * returns:
+         *   'You are enrolling in <span class="course-title">Rock &amp; Roll 101</span>'
+         *
+         * Note: typically the formatString will need to be internationalized, in which
+         * case it will be wrapped with a call to an i18n lookup function. In Django,
+         * this would look like:
+         *
+         *   HtmlUtils.interpolate(
+         *       gettext('You are enrolling in {spanStart}{courseName}{spanEnd}'),
+         *       ...
+         *   );
+         *
+         * @param {string} formatString The string to be interpolated.
+         * @param {Object} parameters An optional set of parameters to the template.
+         * @returns {HtmlSnippet} The resulting safely escaped HTML snippet.
+         */
+        interpolate = function(formatString, parameters) {
+            return formatString.replace(/{\w+}/g,
+                function(parameter) {
+                    var parameterName = parameter.slice(1,-1);
+                    return String(parameters[parameterName]);
+                });
+        };
+
+        return {
+            interpolate: interpolate
+        };
+    });
+}).call(this, define || RequireJS.define);

--- a/test/karma.ci.conf.js
+++ b/test/karma.ci.conf.js
@@ -1,6 +1,6 @@
 // Karma configuration to run in Travis
 
-module.exports = function (config) {
+module.exports = function(config) {
     'use strict';
 
     var baseConfig = require('./karma.conf');

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,6 +1,6 @@
 // Karma configuration
 
-module.exports = function (config, options) {
+module.exports = function(config, options) {
     'use strict';
 
     // If not being overridden, then specify the default headless configuration
@@ -42,7 +42,7 @@ module.exports = function (config, options) {
         ],
 
         // plugins required for running the karma tests
-        plugins:[
+        plugins: [
             'karma-jasmine',
             'karma-jasmine-jquery',
             'karma-requirejs',
@@ -62,8 +62,8 @@ module.exports = function (config, options) {
         reporters: options.reporters,
 
         coverageReporter: {
-            dir:'build', subdir: 'coverage-js',
-            reporters:[
+            dir: 'build', subdir: 'coverage-js',
+            reporters: [
                 {type: 'html', subdir: 'coverage-js/html'},
                 {type: 'cobertura', file: 'coverage.xml'},
                 {type: 'text-summary'}
@@ -78,7 +78,7 @@ module.exports = function (config, options) {
         colors: true,
 
         // level of logging
-        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        // possible values: config.LOG_DISABLE, config.LOG_ERROR, config.LOG_WARN, config.LOG_INFO, config.LOG_DEBUG
         logLevel: options.logLevel,
 
         // enable / disable watching file and executing tests whenever any file changes

--- a/test/karma.debug.conf.js
+++ b/test/karma.debug.conf.js
@@ -1,6 +1,6 @@
 // Karma configuration for debugging
 
-module.exports = function (config) {
+module.exports = function(config) {
     'use strict';
 
     var baseConfig = require('./karma.conf');


### PR DESCRIPTION
https://openedx.atlassian.net/browse/UITK-74

This PR adds a new HtmlUtils class to the UI Toolkit, with two functions:
 - ``HTML(text)`` - wraps a known piece of HTML so that it doesn't get double escaped
 - ``interpolate(string, options)`` - returns an HTML-escaped string where the interpolation escapes each option unless it is an instance of an HTMLSnippet (the result of calling HTML)

Note that we have gone around and around on the name of the helper function. I think it is important that it include the word ``escape`` as its behavior is to return an HTML-escaped string, so I ended up going with Robert's original suggestion.

Once this version of the UI Toolkit has been released, I'll make another PR against edx-platform which will bring in this function and replace some or all usages of ``StringUtils.interpolate_text`` with this new, safer function. We will then update the XSS guidelines to advise folks to use this function instead of any of the alternatives, i.e. interpolate, interpolate_text and _.template.

@AlasdairSwan @robrap please review.

FYI @dan-f @nedbat @cahrens  