### PR TITLE
Improve HTML snippet handling for edx-platform

### DIFF
--- a/gulp/tasks/test-debug.js
+++ b/gulp/tasks/test-debug.js
@@ -6,7 +6,7 @@
         path = require('path'),
         configFile = 'test/karma.debug.conf.js';
 
-    gulp.task('test_debug', function(callback) {
+    gulp.task('test-debug', function(callback) {
         new karma.Server({
             configFile: path.resolve(configFile)
         }, callback).start();

--- a/src/js/utils/html-utils.js
+++ b/src/js/utils/html-utils.js
@@ -6,7 +6,7 @@
  */
 (function(define) {
     'use strict';
-    define(['underscore', './string-utils.js'], function(_, StringUtils) {
+    define(['underscore', 'edx-ui-toolkit/js/utils/string-utils'], function(_, StringUtils) {
         var escape, interpolateHtml, HTML, template;
 
         /**

--- a/src/js/utils/html-utils.js
+++ b/src/js/utils/html-utils.js
@@ -10,54 +10,33 @@
         var escape, interpolateHtml, HTML, template;
 
         /**
-         * Creates an HTML snippet.
-         *
-         * The intention of an HTML snippet is to capture a string that
-         * is known to contain HTML that has been safely escaped.
-         * As an example, this allows interpolate to understand that
-         * it does not need to further escape this HTML.
+         * Helper function to return a string flagged as an HTML snippet.
          *
          * @param {string} htmlString The string of HTML.
-         * @constructor
-         */
-        function HtmlSnippet(htmlString) {
-            this.text = htmlString;
-        }
-        HtmlSnippet.prototype.valueOf = function() {
-            return this.text;
-        };
-        HtmlSnippet.prototype.toString = function() {
-            return this.text;
-        };
-
-        /**
-         * Helper function to create an HTML snippet.
-         *
-         * @param {string} htmlString The string of HTML.
-         * @returns {HtmlSnippet} An HTML snippet that can be safely rendered.
+         * @returns {string} A string flagged as an HTML snippet.
          * @constructor
          */
         HTML = function(htmlString) {
-            return new HtmlSnippet(htmlString);
+            var htmlSnippet = new String(htmlString); // jshint ignore:line
+            htmlSnippet.isHtmlSnippet = true;
+            return htmlSnippet;
         };
 
         /**
-         * Returns HTML that is appropriately escaped.
+         * Returns an HTML string that is appropriately escaped.
          *
-         * If the input is provided as a string, then an HtmlSnippet
-         * is returned with the original text escaped. If the input
-         * is already an HtmlSnippet then it is known to be already
-         * escaped and so it is just returned directly.
+         * Note: if the string provided is flagged as being an HTML snippet
+         * then it will be returned directly so as not to double escape it.
          *
-         * @param {(string|HtmlSnippet)} text Some HTML that is
-         * either provided as a string or as an HtmlSnippet.
-         * @returns {HtmlSnippet} A safely escaped HtmlSnippet.
+         * @param {string} text A string that is either plan text, or is
+         * flagged as being an HTML snippet.
+         * @returns {string} A safely HTML-escaped string.
          */
         escape = function(text) {
-            if (text instanceof HtmlSnippet) {
-                return text;
+            if (text.isHtmlSnippet) {
+                return text.toString();
             } else {
-                return HTML(_.escape(text));
+                return _.escape(text);
             }
         };
 
@@ -97,7 +76,8 @@
          *
          * @param {string} formatString The string to be interpolated.
          * @param {Object} parameters An optional set of parameters to the template.
-         * @returns {HtmlSnippet} The resulting safely escaped HTML snippet.
+         * @returns {string} The resulting safely escaped string flagged as
+         * an HTML snippet.
          */
         interpolateHtml = function(formatString, parameters) {
             var result = StringUtils.interpolate(
@@ -108,7 +88,7 @@
         };
 
         /**
-         * Returns a function that renders an Underscore template as an HTML snippet.
+         * Returns a function that renders an Underscore template as a string.
          *
          * Note: This helper function makes the following context parameters
          * available to the template in addition to those passed in:
@@ -117,7 +97,7 @@
          *
          * @param {string} text
          * @param {object} settings
-         * @returns {function} A function that returns a rendered HTML snippet.
+         * @returns {function} A function that returns a rendered string.
          */
         template = function(text, settings) {
             var HtmlUtils = this,
@@ -129,7 +109,7 @@
                         },
                         data
                     );
-                    return HTML(rawTemplate(augmentedData));
+                    return rawTemplate(augmentedData);
                 };
             return template;
         };
@@ -137,7 +117,6 @@
         return {
             escape: escape,
             HTML: HTML,
-            HtmlSnippet: HtmlSnippet,
             interpolateHtml: interpolateHtml,
             template: template
         };

--- a/src/js/utils/specs/html-utils-spec.js
+++ b/src/js/utils/specs/html-utils-spec.js
@@ -1,21 +1,26 @@
 define(
     [
+        'jquery',
         '../../utils/spec-helpers/spec-helpers.js',
         '../html-utils.js'
     ],
-    function(SpecHelpers, HtmlUtils) {
+    function($, SpecHelpers, HtmlUtils) {
         'use strict';
 
         describe('HtmlUtils', function() {
-            describe('HtmlSnippet', function() {
-                it('can convert to a string', function() {
-                    expect(new HtmlUtils.HtmlSnippet('Hello, world').toString()).toBe('Hello, world');
-                });
-            });
-
             describe('HTML', function() {
-                it('returns an HtmlSnippet', function() {
-                    expect(HtmlUtils.HTML('Hello, world') instanceof HtmlUtils.HtmlSnippet).toBeTruthy();
+                it('returns a string flagged as an HTML snippet', function() {
+                    expect(HtmlUtils.HTML('Hello, world').isHtmlSnippet).toBeTruthy();
+                });
+
+                it('returns an HTML snippet that can be used by JQuery', function() {
+                    var testHtmlString = '<p>A test</p>',
+                        htmlSnippet = HtmlUtils.HTML(testHtmlString);
+                    setFixtures('<div class="test"></div>');
+                    $('.test').html(htmlSnippet);
+                    expect($('.test').html()).toBe(testHtmlString);
+                    $('.test').append(htmlSnippet);
+                    expect($('.test').html()).toBe(testHtmlString + testHtmlString);
                 });
             });
 
@@ -35,13 +40,13 @@ define(
                     ]
                 }, function(input, expectedString) {
                     var result = HtmlUtils.escape(input);
-                    expect(result.toString()).toBe(expectedString);
+                    expect(result).toEqual(expectedString);
                 });
             });
 
             describe('interpolateHtml', function() {
                 it('can interpolate a string with no parameters provided', function() {
-                    expect(HtmlUtils.interpolateHtml('Hello, world').toString()).toBe(
+                    expect(HtmlUtils.interpolateHtml('Hello, world')).toEqual(
                         'Hello, world'
                     );
                 });
@@ -86,7 +91,7 @@ define(
                     ]
                 }, function(template, options, expectedString) {
                     var result = HtmlUtils.interpolateHtml(template, options);
-                    expect(result.toString()).toBe(expectedString);
+                    expect(result).toEqual(expectedString);
                 });
             });
 
@@ -94,13 +99,12 @@ define(
                 it('returns a template that renders correctly', function() {
                     var template = HtmlUtils.template('Hello, <%- name %>'),
                         result = template({name: 'world'});
-                    expect(result instanceof HtmlUtils.HtmlSnippet).toBeTruthy();
-                    expect(result.toString()).toBe('Hello, world');
+                    expect(result).toEqual('Hello, world');
                 });
 
                 it('adds HtmlView as an additional context variable for the template', function() {
                     var template = HtmlUtils.template('I love <%= HtmlUtils.escape("Rock & Roll") %>');
-                    expect(template().toString()).toBe('I love Rock &amp; Roll');
+                    expect(template()).toEqual('I love Rock &amp; Roll');
                 });
             });
         });

--- a/src/js/utils/specs/string-utils-spec.js
+++ b/src/js/utils/specs/string-utils-spec.js
@@ -9,7 +9,7 @@ define(
         describe('StringUtils', function() {
             describe('interpolate', function() {
                 it('can interpolate a string with no parameters provided', function() {
-                    expect(StringUtils.interpolate('Hello, world').toString()).toBe(
+                    expect(StringUtils.interpolate('Hello, world')).toEqual(
                         'Hello, world'
                     );
                 });
@@ -29,7 +29,7 @@ define(
                     ]
                 }, function(template, options, expectedString) {
                     var result = StringUtils.interpolate(template, options);
-                    expect(result.toString()).toBe(expectedString);
+                    expect(result).toEqual(expectedString);
                 });
             });
         });

--- a/src/js/utils/string-utils.js
+++ b/src/js/utils/string-utils.js
@@ -3,7 +3,7 @@
  */
 (function(define) {
     'use strict';
-    define(['underscore', './string-utils.js'], function(_, StringUtils) {
+    define([], function() {
         var interpolate;
 
         /**

--- a/src/js/utils/string-utils.js
+++ b/src/js/utils/string-utils.js
@@ -42,7 +42,7 @@
          *
          * @param {string} formatString The string to be interpolated.
          * @param {Object} parameters An optional set of parameters to the template.
-         * @returns {HtmlSnippet} The resulting safely escaped HTML snippet.
+         * @returns {string} A string with the values interpolated.
          */
         interpolate = function(formatString, parameters) {
             return formatString.replace(/{\w+}/g,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -23,6 +23,12 @@ module.exports = function(config, options) {
         // base path that will be used to resolve all patterns (eg. files, exclude)
         basePath: '../',
 
+        // support the namespace 'edx-ui-toolkit' so that it can be used in the
+        // same way as clients expect to see it.
+        proxies: {
+            '/base/edx-ui-toolkit/': '/base/src/'
+        },
+
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
         frameworks: ['jasmine-jquery', 'jasmine', 'requirejs', 'sinon'],


### PR DESCRIPTION
It turns out that JQuery doesn't call ``toString`` on objects passed to its methods, so our approach of wrapping an HTML string in an object didn't work. At @robrap's suggestion, I'm now creating a string object and setting an ``isHtmlSnippet`` attribute on it. Fortunately almost all of the tests just worked with this fix, and even better you don't need to call ``toString`` before comparing the results.

In addition, I've removed a relative dependency from ``HtmlUtils`` to ``StringUtils`` as that doesn't currently work in edx-platform's Jasmine tests (I'm hoping it will work once we switch to Karma). In order to do this, I've changed the Jasmine tests to proxy dependency paths starting with ``edx-ui-toolkit`` to the correct location.

I'm successfully using these changes in my PR to incorporate the UI Toolkit into the platform:

https://github.com/edx/edx-platform/pull/11799

@robrap @dan-f please review.

FYI @AlasdairSwan @bjacobel 