### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Changelog
 
+## 0.9.0 (2016-03-30)
+* Support loading utility classes into "edx" namespace if RequireJS not available
+* Make StringUtils available as a context parameter to templates
+* Add Coveralls support
+* Fix Karma build failures on Travis
+
+- - -
+
 ## 0.8.0 (2016-03-22)
 * Add more HtmlUtils APIs
+
+- - -
 
 ## 0.7.0 (2016-03-22)
 * Dropdown Menu improved a11y to trap focus in the dropdown for

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ui-toolkit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "homepage": "https://github.com/edx/edx-ui-toolkit",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ui-toolkit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A JavaScript toolkit for building edX user interfaces",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Release 0.9.0
- Support loading utility classes into "edx" namespace if RequireJS not available
- Make StringUtils available as a context parameter to templates
- Add Coveralls support

@AlasdairSwan please review.

FYI @bjacobel 