### PR TITLE
Fix the Travis test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
 
 install:
     - npm install
-    - bower install
 
 script: gulp test --ci
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 A JavaScript toolkit for building edX user interfaces.
 
-[![GitHub version](https://badge.fury.io/gh/edx%2Fedx-ui-toolkit.svg)](https://badge.fury.io/gh/edx%2Fedx-ui-toolkit)  [![npm version](https://badge.fury.io/js/edx-ui-toolkit.svg)](https://badge.fury.io/js/edx-ui-toolkit)  [![Bower version](https://badge.fury.io/bo/edx-ui-toolkit.svg)](https://badge.fury.io/bo/edx-ui-toolkit)
-
+[![GitHub version](https://badge.fury.io/gh/edx%2Fedx-ui-toolkit.svg)](https://badge.fury.io/gh/edx%2Fedx-ui-toolkit)
+[![npm version](https://badge.fury.io/js/edx-ui-toolkit.svg)](https://badge.fury.io/js/edx-ui-toolkit)
+[![Bower version](https://badge.fury.io/bo/edx-ui-toolkit.svg)](https://badge.fury.io/bo/edx-ui-toolkit)
+[![CoverageStatus](https://img.shields.io/coveralls/edx/edx-ui-toolkit.svg)](https://coveralls.io/r/edx/edx-ui-toolkit?branch=master)
 - - -
 
 ## Table of Contents

--- a/src/js/dropdown-menu/specs/dropdown-menu-view-spec.js
+++ b/src/js/dropdown-menu/specs/dropdown-menu-view-spec.js
@@ -13,7 +13,7 @@ define([
                 dropdownModel = new Backbone.Model(),
                 ExtendedDropdownMenuView,
                 singleKeyDown = function(key) {
-                    $(document.activeElement).simulate('keydown', {keyCode: key });
+                    $(document.activeElement).simulate('keydown', {keyCode: key});
                 },
                 focusTrapDown,
                 focusTrapUp,
@@ -35,7 +35,7 @@ define([
 
                     expect($(document.activeElement)).not.toHaveClass('js-dropdown-button');
 
-                    for (i=0; i<listLength; i++) {
+                    for (i = 0; i < listLength; i++) {
                         singleKeyDown(key);
                     }
                 }, timeoutInt);
@@ -50,8 +50,8 @@ define([
                 }, timeoutInt * 3);
 
                 jasmine.clock().tick(timeoutInt + 1);
-                jasmine.clock().tick((timeoutInt * 2 ) + 1);
-                jasmine.clock().tick((timeoutInt * 3 ) + 1);
+                jasmine.clock().tick((timeoutInt * 2) + 1);
+                jasmine.clock().tick((timeoutInt * 3) + 1);
             };
 
             focusTrapUp = function(key) {
@@ -78,8 +78,8 @@ define([
                 }, timeoutInt * 3);
 
                 jasmine.clock().tick(timeoutInt + 1);
-                jasmine.clock().tick((timeoutInt * 2 ) + 1);
-                jasmine.clock().tick((timeoutInt * 3 ) + 1);
+                jasmine.clock().tick((timeoutInt * 2) + 1);
+                jasmine.clock().tick((timeoutInt * 3) + 1);
             };
 
             menuIsClosed = function($btn, $menu) {
@@ -165,7 +165,7 @@ define([
                 }, timeoutInt * 2);
 
                 jasmine.clock().tick(timeoutInt + 1);
-                jasmine.clock().tick((timeoutInt * 2 ) + 1);
+                jasmine.clock().tick((timeoutInt * 2) + 1);
             };
 
             beforeEach(function() {
@@ -221,7 +221,7 @@ define([
                 jasmine.clock().uninstall();
             });
 
-            describe('Default icon useage', function() {
+            describe('Default icon usage', function() {
                 beforeEach(function() {
                     view = new ExtendedDropdownMenuView({
                         className: 'wrapper-more-actions user-menu logged-in',
@@ -346,14 +346,14 @@ define([
                 });
             });
 
-            describe('Pattern Library icon useage', function() {
+            describe('Pattern Library icon usage', function() {
                 beforeEach(function() {
                     dropdownModel.set({
                         button: {
                             icon: 'icon-angle-down',
                             label: 'User options dropdown'
                         }
-                    })
+                    });
                     view = new ExtendedDropdownMenuView({
                         className: 'wrapper-more-actions user-menu logged-in',
                         menuId: 'edx-user-menu',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -31,21 +31,30 @@ module.exports = function(config, options) {
 
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-        frameworks: ['jasmine-jquery', 'jasmine', 'requirejs', 'sinon'],
+        frameworks: ['jasmine-jquery', 'jasmine', 'requirejs'],
 
         // list of files / patterns to load in the browser
         files: [
-            // node_modules/**/*.js contains a LOT of javascript, and
-            // karma runs out of file handles, hence we have to be a
-            // bit more specific:
-            {pattern: 'node_modules/*/*.js', included: false},
-            {pattern: 'node_modules/*/lib/**/*.js', included: false},
-            {pattern: 'node_modules/*/src/*.js', included: false},
-            {pattern: 'src/js/**/*.js', included: false},
-            {pattern: 'src/js/**/*.underscore', included: false},
+            // load the Karma spec runner
+            'test/spec-runner.js',
+
+            // load the RequireJS configuration
+            'test/require-config.js',
+
+           // load third party libraries
+            'node_modules/underscore/underscore.js',
+
+            // register third party libraries to be loaded via RequireJS
+            {pattern: 'node_modules/backbone/backbone.js', included: false},
+            {pattern: 'node_modules/backbone.paginator/lib/backbone.paginator.js', included: false},
+            {pattern: 'node_modules/requirejs-text/text.js', included: false},
+            {pattern: 'node_modules/sinon/**/*.js', included: false},
+            {pattern: 'node_modules/urijs/src/*.js', included: false},
             {pattern: 'test/jquery.simulate.js', included: false},
-            {pattern: 'test/require-config.js', included: true},
-            {pattern: 'test/spec-runner.js', included: true}
+
+            // register all the UI Toolkit source and Underscore templates
+            {pattern: 'src/js/**/*.js', included: false},
+            {pattern: 'src/js/**/*.underscore', included: false}
         ],
 
         // plugins required for running the karma tests

--- a/test/require-config.js
+++ b/test/require-config.js
@@ -3,15 +3,15 @@
  */
 
 require.config({
-    baseUrl: '/',
+    baseUrl: '/base',
     waitSeconds: 60,
     paths: {
-        backbone: 'node_modules/backbone/backbone-min',
-        'backbone.paginator': 'node_modules/backbone.paginator/lib/backbone.paginator.min',
-        jquery: 'node_modules/jquery/dist/jquery.min',
+        backbone: 'node_modules/backbone/backbone',
+        'backbone.paginator': 'node_modules/backbone.paginator/lib/backbone.paginator',
+        jquery: 'node_modules/jquery/dist/jquery',
         'jquery.simulate': 'test/jquery.simulate',
         text: 'node_modules/requirejs-text/text',
-        underscore: 'node_modules/underscore/underscore-min',
+        underscore: 'node_modules/underscore/underscore',
         sinon: 'node_modules/sinon/lib/sinon',
 
         // URI and its dependencies
@@ -22,6 +22,9 @@ require.config({
     },
     wrapShim: true,
     shim: {
+        jquery: {
+            exports: '$'
+        },
         backbone: {
             deps: ['underscore', 'jquery'],
             exports: 'Backbone',
@@ -33,7 +36,7 @@ require.config({
         },
         'jquery.simulate': {
             deps: ['jquery'],
-            exports: ['jquery.simulate']
+            exports: ['$.simulate']
         },
         underscore: {
             exports: '_'


### PR DESCRIPTION
After a lot of research, I stumbled upon this Stack Overflow answer:

http://stackoverflow.com/questions/20733090/karma-error-there-is-no-timestamp-for/21153198#21153198

The problem seems to be some combination of the Karma configuration, the RequireJS configuration and PhantomJS. I've cleaned up the Karma configuration so that it loads files in an optimal order, and so that it doesn't accidentally include random other JS files from node_modules. In particular, it loads Underscore immediately rather than via RequireJS, because other libraries assume that it can be accessed from the global namespace. I've also fixed the RequireJS configuration so that it shims JQuery since it is pre-loaded by Jasmine-JQuery.

I've also experimented with removing the PhantomJS browser from the Travis tests. I think it isn't necessary since we're testing with both Chrome and Firefox. My build passed once without it, but I've added it back for the moment as I'm not convinced that that was necessary.

@AlasdairSwan @bjacobel please review.

FYI @dan-f @dsjen @benpatterson @jzoldak 