### PR TITLE
Update README to gulp test-debug (with a hyphen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To run tests in headless mode:
 
 To run tests in debug mode:
 
-        $ gulp test_debug
+        $ gulp test-debug
 
 Once tests are running in debug mode, open this URL:
 


### PR DESCRIPTION
A tiny documentation fix: https://github.com/edx/edx-ui-toolkit/blob/master/gulp/tasks/test-debug.js#L9