### PR TITLE
Fix issues with karma hanging on exit

### DIFF
--- a/gulp/tasks/jscs.js
+++ b/gulp/tasks/jscs.js
@@ -5,7 +5,7 @@
         gulp = require('gulp'),
         paths = {
             lint: [
-                'test/**/*.js',
+                'test/**/!(jquery.simulate)*.js',
                 'components/**/*.js',
                 'gulp/tasks/*.js',
                 'gulpfile.js'

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -5,7 +5,7 @@
         gulp = require('gulp'),
         paths = {
             lint: [
-                'test/**/*.js',
+                'test/**/!(jquery.simulate)*.js',
                 'components/**/*.js',
                 'gulp/tasks/*.js',
                 'gulpfile.js'

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "javascript"
   ],
   "homepage": "https://github.com/edx/edx-ui-toolkit",
+  "scripts": {
+    "test": "gulp test"
+  },
   "dependencies": {
     "backbone": "~1.2.3",
     "backbone.paginator": "~2.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "gulp-coveralls": "~0.1.4",
     "gulp-jscs": "~3.0.2",
     "gulp-jshint": "~2.0.0",
-    "gulp-karma": "~0.0.5",
     "gulp-util": "~3.0.7",
     "jasmine": "~2.4.1",
     "jasmine-core": "~2.4.1",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -83,8 +83,7 @@ module.exports = function(config, options) {
             reporters: [
                 {type: 'html', subdir: 'coverage-js/html'},
                 {type: 'cobertura', file: 'coverage.xml'},
-                {type: 'lcov', dir: 'coverage/'},
-                {type: 'text-summary'}
+                {type: 'lcov', dir: 'coverage/'}
             ]
         },
 


### PR DESCRIPTION
See issue [here](https://github.com/karma-runner/karma-coverage/issues/209#issuecomment-205852972). `karma-coverage` with reporters `text` and `text-summary` and our setup for some reason has an issue where it will hang for ~30 seconds prior to exiting. Since coverage reports are only marginally helpful in development, this PR removes the `text-summary` reporter. (It doesn't affect Coveralls.)

Also tweaks a few other things around the Karma setup:
- adds ability to run tests with `npm test`, which means you don't need to install Gulp globally
- removes a library that wasn't doing anything
- fixes linting issues

cc @andy-armstrong 