### PR TITLE
Upgrade AjaxHelpers to match edx-platform

### DIFF
--- a/src/js/pagination/specs/paging-collection-spec.js
+++ b/src/js/pagination/specs/paging-collection-spec.js
@@ -6,53 +6,56 @@ define(['jquery',
         '../../utils/spec-helpers/ajax-helpers.js',
         '../../utils/spec-helpers/spec-helpers.js'
     ],
-    function ($, Backbone, _, URI, PagingCollection, AjaxHelpers, SpecHelpers) {
+    function($, Backbone, _, URI, PagingCollection, AjaxHelpers, SpecHelpers) {
         'use strict';
 
-        describe('PagingCollection', function () {
+        describe('PagingCollection', function() {
             var collection;
             var server = {
                 isZeroIndexed: false,
                 count: 43,
-                respond: function (requests) {
-                    var params = (new URI(requests[requests.length - 1].url)).query(true),
+                respond: function(requests) {
+                    var request = AjaxHelpers.currentRequest(requests),
+                        params = (new URI(request.url)).query(true),
                         page = parseInt(params.page, 10),
-                        page_size = parseInt(params.page_size, 10),
-                        page_count = Math.ceil(this.count / page_size);
+                        pageSize = parseInt(params.page_size, 10),
+                        pageCount = Math.ceil(this.count / pageSize);
 
                     // Make zeroPage consistently start at zero for ease of calculation
                     var zeroPage = page - (this.isZeroIndexed ? 0 : 1);
-                    if (zeroPage < 0 || zeroPage > page_count) {
-                        AjaxHelpers.respondWithError(requests, 404, {}, requests.length - 1);
+                    if (zeroPage < 0 || zeroPage > pageCount) {
+                        AjaxHelpers.respondWithError(requests, 404);
                     } else {
                         AjaxHelpers.respondWithJson(requests, {
                             count: this.count,
                             current_page: page,
-                            num_pages: page_count,
-                            start: zeroPage * page_size,
+                            num_pages: pageCount,
+                            start: zeroPage * pageSize,
                             results: []
-                        }, requests.length - 1);
+                        });
                     }
                 }
             };
-            var getUrlParams = function (request) {
+            var getUrlParams = function(request) {
                 return (new URI(request.url)).query(true);
             };
-            var assertQueryParams = function (requests, params) {
-                var urlParams = getUrlParams(requests[requests.length - 1]);
-                _.each(params, function (value, key) {
+            var assertQueryParams = function(requests, params) {
+                var request = AjaxHelpers.currentRequest(requests),
+                    urlParams = getUrlParams(request);
+                _.each(params, function(value, key) {
                     expect(urlParams[key]).toBe(value);
                 });
+                server.respond(requests);
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 collection = new PagingCollection([], {state: {pageSize: 10}});
                 collection.url = '/test';
                 server.isZeroIndexed = false;
                 server.count = 43;
             });
 
-            it('correctly merges state and queryParams in the extend statement', function () {
+            it('correctly merges state and queryParams in the extend statement', function() {
                 var MyPagingCollection, newCollection;
                 MyPagingCollection = PagingCollection.extend({
                     state: {pageSize: 25},
@@ -77,7 +80,7 @@ define(['jquery',
                     numPages: 3,
                     pageSize: 15
                 }]
-            }, function (method, expectedState) {
+            }, function(method, expectedState) {
                 var newCollection;
                 newCollection = new PagingCollection({
                     count: 43,
@@ -112,87 +115,80 @@ define(['jquery',
                 }
             });
 
-            it('can register sortable fields', function () {
+            it('can register sortable fields', function() {
                 collection.registerSortableField('test_field', 'Test Field');
                 expect('test_field' in collection.sortableFields).toBe(true);
                 expect(collection.sortableFields.test_field.displayName).toBe('Test Field');
             });
 
-            it('can register filterable fields', function () {
+            it('can register filterable fields', function() {
                 collection.registerFilterableField('test_field', 'Test Field');
                 expect('test_field' in collection.filterableFields).toBe(true);
                 expect(collection.filterableFields.test_field.displayName).toBe('Test Field');
             });
 
-            it('can set the sort field', AjaxHelpers.requests(
-                function (requests) {
-                    expect(collection.sortDisplayName()).toBe('');
-                    collection.registerSortableField('test_field', 'Test Field');
-                    collection.setSortField('test_field', false);
-                    collection.refresh();
-                    assertQueryParams(requests, {'sort_order': 'asc'});
-                    expect(collection.state.sortKey).toBe('test_field');
-                    expect(collection.sortDisplayName()).toBe('Test Field');
-                }
-            ));
+            it('can set the sort field', AjaxHelpers.withFakeRequests(function(requests) {
+                expect(collection.sortDisplayName()).toBe('');
+                collection.registerSortableField('test_field', 'Test Field');
+                collection.setSortField('test_field', false);
+                collection.refresh();
+                assertQueryParams(requests, {'sort_order': 'asc'});
+                expect(collection.state.sortKey).toBe('test_field');
+                expect(collection.sortDisplayName()).toBe('Test Field');
+            }));
 
-            it('can tell the current sort direction', function () {
+            it('can tell the current sort direction', function() {
                 collection.setSortDirection(PagingCollection.SortDirection.ASCENDING);
                 expect(collection.sortDirection()).toBe(PagingCollection.SortDirection.ASCENDING);
                 collection.setSortDirection(PagingCollection.SortDirection.DESCENDING);
                 expect(collection.sortDirection()).toBe(PagingCollection.SortDirection.DESCENDING);
             });
 
-            it('can set a filter field', AjaxHelpers.requests(
-                function (requests) {
-                    expect(collection.filterDisplayName('test_field')).toBe('');
-                    collection.registerFilterableField('test_field', 'Test Field');
-                    collection.setFilterField('test_field', 'test_value');
-                    collection.refresh();
-                    assertQueryParams(requests, {'test_field': 'test_value'});
-                    expect(collection.filterDisplayName('test_field')).toBe('Test Field');
-                    expect(collection.getFilterFieldValue('test_field')).toBe('test_value');
-                }
-            ));
+            it('can set a filter field', AjaxHelpers.withFakeRequests(function(requests) {
+                expect(collection.filterDisplayName('test_field')).toBe('');
+                collection.registerFilterableField('test_field', 'Test Field');
+                collection.setFilterField('test_field', 'test_value');
+                collection.refresh();
+                assertQueryParams(requests, {'test_field': 'test_value'});
+                expect(collection.filterDisplayName('test_field')).toBe('Test Field');
+                expect(collection.getFilterFieldValue('test_field')).toBe('test_value');
+            }));
 
-            it('can set a filter field to an array', AjaxHelpers.requests(
-                function (requests) {
-                    expect(collection.filterDisplayName('test_field')).toBe('');
-                    collection.registerFilterableField('test_field', 'Test Field');
-                    collection.setFilterField('test_field', ['a', 'b', 'c']);
-                    collection.refresh();
-                    assertQueryParams(requests, {'test_field': 'a,b,c'});
-                    expect(collection.filterDisplayName('test_field')).toBe('Test Field');
-                    expect(collection.getFilterFieldValue('test_field')).toEqual(['a', 'b', 'c']);
-                }
-            ));
+            it('can set a filter field to an array', AjaxHelpers.withFakeRequests(function(requests) {
+                expect(collection.filterDisplayName('test_field')).toBe('');
+                collection.registerFilterableField('test_field', 'Test Field');
+                collection.setFilterField('test_field', ['a', 'b', 'c']);
+                collection.refresh();
+                assertQueryParams(requests, {'test_field': 'a,b,c'});
+                expect(collection.filterDisplayName('test_field')).toBe('Test Field');
+                expect(collection.getFilterFieldValue('test_field')).toEqual(['a', 'b', 'c']);
+            }));
 
-            it('can set many filter fields', AjaxHelpers.requests(
-                function (requests) {
-                    collection.registerFilterableField('test_field_1', 'Test Field 1');
-                    collection.registerFilterableField('test_field_2', 'Test Field 2');
-                    collection.setFilterField('test_field_1', 'test_value_1');
-                    collection.setFilterField('test_field_2', 'test_value_2');
-                    collection.refresh();
-                    assertQueryParams(requests, {test_field_1: 'test_value_1', test_field_2: 'test_value_2'});
-                    expect(collection.filterDisplayName('test_field_1')).toBe('Test Field 1');
-                    expect(collection.filterDisplayName('test_field_2')).toBe('Test Field 2');
-                    expect(collection.filterableFields.test_field_1.value).toBe('test_value_1');
-                    expect(collection.filterableFields.test_field_2.value).toBe('test_value_2');
-                }
-            ));
+            it('can set many filter fields', AjaxHelpers.withFakeRequests(function(requests) {
+                collection.registerFilterableField('test_field_1', 'Test Field 1');
+                collection.registerFilterableField('test_field_2', 'Test Field 2');
+                collection.setFilterField('test_field_1', 'test_value_1');
+                collection.setFilterField('test_field_2', 'test_value_2');
+                collection.refresh();
+                assertQueryParams(requests, {test_field_1: 'test_value_1', test_field_2: 'test_value_2'});
+                expect(collection.filterDisplayName('test_field_1')).toBe('Test Field 1');
+                expect(collection.filterDisplayName('test_field_2')).toBe('Test Field 2');
+                expect(collection.filterableFields.test_field_1.value).toBe('test_value_1');
+                expect(collection.filterableFields.test_field_2.value).toBe('test_value_2');
+            }));
 
-            it('can unset a filter field', AjaxHelpers.requests(function (requests) {
+            it('can unset a filter field', AjaxHelpers.withFakeRequests(function(requests) {
                 collection.registerFilterableField('test_field', 'Test Field');
                 collection.setFilterField('test_field', 'test_value');
                 collection.refresh();
                 assertQueryParams(requests, {test_field: 'test_value'});
                 collection.unsetAllFilterFields();
                 collection.refresh();
-                expect('test_field' in getUrlParams(requests[requests.length - 1])).not.toBe(true);
+                expect('test_field' in getUrlParams(AjaxHelpers.currentRequest(requests))).not.toBe(true);
             }));
 
-            it('can unset all filter fields', AjaxHelpers.requests(function (requests) {
+            it('can unset all filter fields', AjaxHelpers.withFakeRequests(function(requests) {
+                var currentRequest;
                 collection.registerFilterableField('test_field_1', 'Test Field 1');
                 collection.registerFilterableField('test_field_2', 'Test Field 2');
                 collection.setFilterField('test_field_1', 'test_value_1');
@@ -201,11 +197,12 @@ define(['jquery',
                 assertQueryParams(requests, {test_field_1: 'test_value_1', test_field_2: 'test_value_2'});
                 collection.unsetAllFilterFields();
                 collection.refresh();
-                expect('test_field_1' in getUrlParams(requests[requests.length - 1])).not.toBe(true);
-                expect('test_field_2' in getUrlParams(requests[requests.length - 1])).not.toBe(true);
+                currentRequest = AjaxHelpers.currentRequest(requests);
+                expect('test_field_1' in getUrlParams(currentRequest)).not.toBe(true);
+                expect('test_field_2' in getUrlParams(currentRequest)).not.toBe(true);
             }));
 
-            it('can return the currently active filter fields', function () {
+            it('can return the currently active filter fields', function() {
                 collection.registerFilterableField('test_field_1', 'Test Field 1');
                 collection.registerFilterableField('test_field_2', 'Test Field 2');
                 collection.registerFilterableField('test_field_3', 'Test Field 3');
@@ -216,7 +213,7 @@ define(['jquery',
                     .toEqual({test_field_1: 'test_value_1', test_field_3: 'test_value_3'});
             });
 
-            it('can return the currently active filter fields, including search', function () {
+            it('can return the currently active filter fields', AjaxHelpers.withFakeRequests(function(requests) {
                 var expectedRequestBody;
                 collection.registerFilterableField('test_field', 'Test Field');
                 collection.setFilterField('test_field', 'test value');
@@ -224,15 +221,15 @@ define(['jquery',
                 expectedRequestBody = {test_field: 'test value'};
                 expectedRequestBody[PagingCollection.DefaultSearchKey] = 'test search';
                 expect(collection.getActiveFilterFields(true)).toEqual(expectedRequestBody);
-            });
+            }));
 
-            it('can tell if there is an active search', function () {
+            it('can tell if there is an active search', function() {
                 expect(collection.hasActiveSearch()).toBe(false);
                 collection.setSearchString('test search');
                 expect(collection.hasActiveSearch()).toBe(true);
             });
 
-            it('can get the value of a particular filter field', function () {
+            it('can get the value of a particular filter field', function() {
                 collection.registerFilterableField('test_field_1', 'Test Field 1');
                 collection.registerFilterableField('test_field_2', 'Test Field 2');
                 collection.setFilterField('test_field_1', 'test_value_1');
@@ -243,32 +240,28 @@ define(['jquery',
                 expect(collection.getFilterFieldValue('no_such_field')).toBe(null);
             });
 
-            it('can set the sort direction', AjaxHelpers.requests(
-                function (requests) {
-                    collection.setSortField('test_field');
-                    collection.setSortDirection(PagingCollection.SortDirection.DESCENDING);
-                    collection.refresh();
-                    assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.DESCENDING});
-                    expect(collection.sortDirection()).toBe(PagingCollection.SortDirection.DESCENDING);
-                    collection.setSortDirection(PagingCollection.SortDirection.ASCENDING);
-                    collection.refresh();
-                    assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.ASCENDING});
-                    expect(collection.sortDirection()).toBe(PagingCollection.SortDirection.ASCENDING);
-                }
-            ));
+            it('can set the sort direction', AjaxHelpers.withFakeRequests(function(requests) {
+                collection.setSortField('test_field');
+                collection.setSortDirection(PagingCollection.SortDirection.DESCENDING);
+                collection.refresh();
+                assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.DESCENDING});
+                expect(collection.sortDirection()).toBe(PagingCollection.SortDirection.DESCENDING);
+                collection.setSortDirection(PagingCollection.SortDirection.ASCENDING);
+                collection.refresh();
+                assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.ASCENDING});
+                expect(collection.sortDirection()).toBe(PagingCollection.SortDirection.ASCENDING);
+            }));
 
-            it('can flip the sort direction', AjaxHelpers.requests(
-                function (requests) {
-                    collection.setSortField('test_field');
-                    collection.refresh();
-                    assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.ASCENDING});
-                    collection.flipSortDirection();
-                    collection.refresh();
-                    assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.DESCENDING});
-                }
-            ));
+            it('can flip the sort direction', AjaxHelpers.withFakeRequests(function(requests) {
+                collection.setSortField('test_field');
+                collection.refresh();
+                assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.ASCENDING});
+                collection.flipSortDirection();
+                collection.refresh();
+                assertQueryParams(requests, {'sort_order': PagingCollection.SortDirection.DESCENDING});
+            }));
 
-            it('can toggle the sort direction when setting the sort field', function () {
+            it('can toggle the sort direction when setting the sort field', function() {
                 collection.registerSortableField('test_field', 'Test Field');
                 collection.registerSortableField('test_field_2', 'Test Field 2');
                 collection.setSortField('test_field', true);
@@ -283,24 +276,23 @@ define(['jquery',
                 expect(collection.sortDirection()).toBe(PagingCollection.SortDirection.ASCENDING);
             });
 
-            it('can set and unset the search string', AjaxHelpers.requests(function (requests) {
+            it('can set and unset the search string', AjaxHelpers.withFakeRequests(function(requests) {
                 collection.setSearchString('testString');
                 collection.refresh();
                 assertQueryParams(requests, {'text_search': 'testString'});
                 collection.unsetSearchString();
                 collection.refresh();
-                expect('text_search' in getUrlParams(requests[requests.length - 1])).not.toBe(true);
+                expect('text_search' in getUrlParams(AjaxHelpers.currentRequest(requests))).not.toBe(true);
             }));
 
-            it('can get the current search string', AjaxHelpers.requests(function (requests) {
+            it('can get the current search string', AjaxHelpers.withFakeRequests(function(requests) {
                 collection.setSearchString('test string');
                 collection.refresh();
                 server.respond(requests);
                 expect(collection.getSearchString()).toBe('test string');
             }));
 
-            it('does not refresh itself if the search string is unchanged',
-                AjaxHelpers.requests(function (requests) {
+            it('does not refresh if search string is unchanged', AjaxHelpers.withFakeRequests(function(requests) {
                     var testString = 'testString';
                     collection.setSearchString(testString);
                     collection.refresh();
@@ -314,7 +306,7 @@ define(['jquery',
             SpecHelpers.withData({
                 'queries with page, page_size, and sort_order parameters when zero indexed': [true, 2],
                 'queries with page, page_size, and sort_order parameters when one indexed': [false, 3]
-            }, AjaxHelpers.requests(function (isZeroIndexed, page, requests) {
+            }, AjaxHelpers.withFakeRequests(function(isZeroIndexed, page, requests) {
                 collection = new PagingCollection([], {state: {firstPage: isZeroIndexed ? 0 : 1, pageSize: 5}});
                 collection.url = '/test';
                 collection.setSortField('test_field');
@@ -324,7 +316,7 @@ define(['jquery',
                 });
             }));
 
-            it('has instance-unique filterableFields and sortablefields', function () {
+            it('has instance-unique filterableFields and sortablefields', function() {
                 var otherCollection = new PagingCollection([], {state: {pageSize: 10}});
                 collection.registerFilterableField('foo', 'foo');
                 collection.setFilterField('foo', 'bar');
@@ -336,15 +328,15 @@ define(['jquery',
             SpecHelpers.withConfiguration({
                 'using a zero indexed collection': [true],
                 'using a one indexed collection': [false]
-            }, function (isZeroIndexed) {
+            }, function(isZeroIndexed) {
                 collection.state.firstPage = isZeroIndexed ? 0 : 1;
                 server.isZeroIndexed = isZeroIndexed;
-            }, function () {
+            }, function() {
                 describe('setPage', function() {
                     it('triggers a reset event when the page changes successfully',
-                        AjaxHelpers.requests(function (requests) {
+                        AjaxHelpers.withFakeRequests(function(requests) {
                             var resetTriggered = false;
-                            collection.on('reset', function () { resetTriggered = true; });
+                            collection.on('reset', function() { resetTriggered = true; });
                             collection.setPage(3);
                             server.respond(requests);
                             expect(resetTriggered).toBe(true);
@@ -352,11 +344,9 @@ define(['jquery',
                     );
 
                     it('triggers an error event when the requested page is out of range',
-                        AjaxHelpers.requests(function (requests) {
+                        AjaxHelpers.withFakeRequests(function(requests) {
                             var errorTriggered = false;
-                            collection.on('error', function () {
-                                errorTriggered = true;
-                            });
+                            collection.on('error', function() { errorTriggered = true; });
                             collection.setPage(17);
                             server.respond(requests);
                             // TODO: re-enable this...
@@ -365,14 +355,14 @@ define(['jquery',
                     );
 
                     it('triggers an error event if the server responds with a 500',
-                        AjaxHelpers.requests(function (requests) {
+                        AjaxHelpers.withFakeRequests(function(requests) {
                             var errorTriggered = false;
-                            collection.on('error', function () { errorTriggered = true; });
+                            collection.on('error', function() { errorTriggered = true; });
                             collection.setPage(2);
                             expect(collection.getPageNumber()).toBe(2);
                             server.respond(requests);
                             collection.setPage(3);
-                            AjaxHelpers.respondWithError(requests, 500, {}, requests.length - 1);
+                            AjaxHelpers.respondWithError(requests);
                             // TODO: re-enable this...
                             // expect(errorTriggered).toBe(true);
                             // expect(collection.getPageNumber()).toBe(2);
@@ -380,8 +370,8 @@ define(['jquery',
                     );
                 });
 
-                describe('getPageNumber', function () {
-                    it('returns the correct page', AjaxHelpers.requests(function (requests) {
+                describe('getPageNumber', function() {
+                    it('returns the correct page', AjaxHelpers.withFakeRequests(function(requests) {
                         collection.setPage(1);
                         server.respond(requests);
                         expect(collection.getPageNumber()).toBe(1);
@@ -391,7 +381,7 @@ define(['jquery',
                     }));
                 });
 
-                describe('hasNextPage', function () {
+                describe('hasNextPage', function() {
                     SpecHelpers.withData(
                         {
                             'returns false for a single page': [1, 3, false],
@@ -399,7 +389,7 @@ define(['jquery',
                             'returns true on the penultimate page': [4, 43, true],
                             'returns false on the last page': [5, 43, false]
                         },
-                        AjaxHelpers.requests(function (page, count, result, requests) {
+                        AjaxHelpers.withFakeRequests(function(page, count, result, requests) {
                             server.count = count;
                             collection.setPage(page);
                             server.respond(requests);
@@ -408,7 +398,7 @@ define(['jquery',
                     );
                 });
 
-                describe('hasPreviousPage', function () {
+                describe('hasPreviousPage', function() {
                     SpecHelpers.withData(
                         {
                             'returns false for a single page': [1, 3, false],
@@ -416,7 +406,7 @@ define(['jquery',
                             'returns true on the second page': [2, 43, true],
                             'returns false on the first page': [1, 43, false]
                         },
-                        AjaxHelpers.requests(function (page, count, result, requests) {
+                        AjaxHelpers.withFakeRequests(function(page, count, result, requests) {
                             server.count = count;
                             collection.setPage(page);
                             server.respond(requests);
@@ -425,13 +415,13 @@ define(['jquery',
                     );
                 });
 
-                describe('nextPage', function () {
+                describe('nextPage', function() {
                     SpecHelpers.withData(
                         {
                             'advances to the next page': [2, 43, 3],
                             'silently fails on the last page': [5, 43, 5]
                         },
-                        AjaxHelpers.requests(function (page, count, newPage, requests) {
+                        AjaxHelpers.withFakeRequests(function(page, count, newPage, requests) {
                             server.count = count;
                             collection.setPage(page);
                             server.respond(requests);
@@ -445,13 +435,13 @@ define(['jquery',
                     );
                 });
 
-                describe('previousPage', function () {
+                describe('previousPage', function() {
                     SpecHelpers.withData(
                         {
                             'moves to the previous page': [2, 43, 1],
                             'silently fails on the first page': [1, 43, 1]
                         },
-                        AjaxHelpers.requests(function (page, count, newPage, requests) {
+                        AjaxHelpers.withFakeRequests(function(page, count, newPage, requests) {
                             server.count = count;
                             collection.setPage(page);
                             server.respond(requests);

--- a/src/js/utils/spec-helpers/ajax-helpers.js
+++ b/src/js/utils/spec-helpers/ajax-helpers.js
@@ -15,85 +15,165 @@
 define(['sinon', 'underscore', 'URI'], function(sinon, _, URI) {
     'use strict';
 
-    var fakeRequests, expectRequest, expectJsonRequest, expectPostRequest, expectRequestURL,
-        respondWithJson, respondWithError, respondWithTextError, respondWithNoContent;
+    var XHR_READY_STATES, fakeServer, createFakeRequests, withFakeRequests, fakeRequests, currentRequest,
+        expectRequest, expectNoRequests, expectJsonRequest, expectPostRequest, expectRequestURL, skipResetRequest,
+        respond, respondWithJson, respondWithError, respondWithTextError, respondWithNoContent;
 
     /**
-     * Keep track of all requests to a fake server, and call `spec`
-     * with a reference to the server. Allows tests to respond to
-     * individual requests.
+     * An enumeration of valid XHR ready states.
      */
-    fakeRequests = function (spec) {
-        return function () {
-            var requests = [],
-                xhr = sinon.useFakeXMLHttpRequest(),
-                args = Array.prototype.slice.call(arguments);
-            xhr.onCreate = function(request) {
-                requests.push(request);
-            };
-            spec.apply(null, args.concat([requests]));
-            xhr.restore();
+    XHR_READY_STATES = {
+        UNSENT: 0,
+        OPENED: 1,
+        LOADING: 3,
+        DONE: 4
+    };
+
+    /* These utility methods are used by Jasmine tests to create a mock server or
+     * get reference to mock requests. In either case, the cleanup (restore) is done with
+     * an after function.
+     *
+     * This pattern is being used instead of the more common beforeEach/afterEach pattern
+     * because we were seeing sporadic failures in the afterEach restore call. The cause of the
+     * errors were that one test suite was incorrectly being linked as the parent of an unrelated
+     * test suite (causing both suites' afterEach methods to be called). No solution for the root
+     * cause has been found, but initializing sinon and cleaning it up on a method-by-method
+     * basis seems to work. For more details, see STUD-1264.
+     */
+
+    /**
+     * Get a reference to the mocked server, and respond to all requests
+     * with the specified response.
+     *
+     * @param {string} response the fake response.
+     * @returns {*} The current request.
+     */
+    fakeServer = function(response) {
+        var server = sinon.fakeServer.create();
+        afterEach(function() {
+            if (server) {
+                server.restore();
+            }
+        });
+        server.respondWith(response);
+        return server;
+    };
+
+    createFakeRequests = function() {
+        var requests = [],
+            xhr = sinon.useFakeXMLHttpRequest();
+
+        requests.currentIndex = 0;
+        requests.restore = function() {
+            if (xhr && xhr.hasOwnProperty('restore')) {
+                xhr.restore();
+            }
         };
+        xhr.onCreate = function(request) {
+            requests.push(request);
+        };
+
+        return requests;
+    };
+
+    /**
+     * Keep track of all requests to a fake server, and return a reference to the Array.
+     * This allows tests to respond to individual requests.
+     *
+     * @returns {Array} An array tracking the fake requests.
+     */
+    fakeRequests = function() {
+        var requests = createFakeRequests();
+        afterEach(function() {
+            requests.restore();
+        });
+        return requests;
+    };
+
+    /**
+     * Wraps a test function so that it is invoked with an additional parameter
+     * containing an array of fake HTTP requests.
+     *
+     * @param {function} test A function to be invoked with the fake requests.
+     * @returns {function} A wrapped version of the input function.
+     */
+    withFakeRequests = function(test) {
+        return function() {
+            var requests = createFakeRequests(),
+                args = Array.prototype.slice.call(arguments);
+            test.apply(null, args.concat([requests]));
+            requests.restore();
+        };
+    };
+
+    /**
+     * Returns the request that has not yet been responded to. If no such request
+     * is available then the current test will fail.
+     *
+     * @param {object} requests an array of fired sinon requests
+     * @returns {*} The current request.
+     */
+    currentRequest = function(requests) {
+        expect(requests.length).toBeGreaterThan(requests.currentIndex);
+        return requests[requests.currentIndex];
     };
 
     /**
      * Expect that a request was made as expected.
      *
-     * @param requests an array of fired sinon requests
-     * @param method the expected method of the request
-     * @param url the expected url of the request
-     * @param body the expected request body
-     * @param requestIndex the expected index of the request in the
-     *     array (higher indices occur later).  Defaults to
-     *     requests.length - 1.
+     * @param {object} requests an array of fired sinon requests
+     * @param {string} method the expected method of the request
+     * @param {string} url the expected url of the request
+     * @param {string} body the expected request body
      */
-    expectRequest = function(requests, method, url, body, requestIndex) {
-        var request;
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        request = requests[requestIndex];
+    expectRequest = function(requests, method, url, body) {
+        var request = currentRequest(requests);
+        expect(request.readyState).toEqual(XHR_READY_STATES.OPENED);
         expect(request.url).toEqual(url);
         expect(request.method).toEqual(method);
+        if (typeof body === 'undefined') {
+            // The body of the request may not be germane to the current test,
+            // such as a call by a library, so allow it to be ignored.
+            return;
+        }
         expect(request.requestBody).toEqual(body);
+    };
+
+    /**
+     * Verifies that there are no unconsumed requests.
+     *
+     * @param {object} requests an array of fired sinon requests
+     */
+    expectNoRequests = function(requests) {
+        expect(requests.length).toEqual(requests.currentIndex);
     };
 
     /**
      * Expect that a request with a JSON payload was made as expected.
      *
-     * @param requests an array of fired sinon requests
-     * @param method the expected method of the request
-     * @param url the expected url of the request
-     * @param jsonBody the expected request body as an object
-     * @param requestIndex the expected index of the request in the
-     *     array (higher indices occur later).  Defaults to
-     *     requests.length - 1.
+     * @param {object} requests an array of fired sinon requests
+     * @param {string} method the expected method of the request
+     * @param {string} url the expected url of the request
+     * @param {object} jsonRequest the expected request body as an object
      */
-    expectJsonRequest = function(requests, method, url, jsonBody, requestIndex) {
-        var request;
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        request = requests[requestIndex];
+    expectJsonRequest = function(requests, method, url, jsonRequest) {
+        var request = currentRequest(requests);
+        expect(request.readyState).toEqual(XHR_READY_STATES.OPENED);
         expect(request.url).toEqual(url);
         expect(request.method).toEqual(method);
-        expect(JSON.parse(request.requestBody)).toEqual(jsonBody);
+        expect(JSON.parse(request.requestBody)).toEqual(jsonRequest === undefined ? null : jsonRequest);
     };
 
     /**
      * Expect that a JSON request be made with the given URL and parameters.
      *
-     * @param requests The collected requests
-     * @param expectedUrl The expected URL excluding the parameters
-     * @param expectedParameters An object representing the URL parameters
-     * @param requestIndex An optional index for the request (by default, the last request is used)
+     * @param {object} requests The collected requests
+     * @param {string} expectedUrl The expected URL excluding the parameters
+     * @param {object} expectedParameters An object representing the URL parameters
      */
-    expectRequestURL = function(requests, expectedUrl, expectedParameters, requestIndex) {
-        var request, parameters;
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        request = requests[requestIndex];
+    expectRequestURL = function(requests, expectedUrl, expectedParameters) {
+        var request = currentRequest(requests),
+            parameters;
         expect(new URI(request.url).path()).toEqual(expectedUrl);
         parameters = new URI(request.url).query(true);
         delete parameters._;  // Ignore the cache-busting argument
@@ -101,122 +181,124 @@ define(['sinon', 'underscore', 'URI'], function(sinon, _, URI) {
     };
 
     /**
-     * Intended for use with POST requests using
-     * application/x-www-form-urlencoded.
+     * Intended for use with POST requests using application/x-www-form-urlencoded.
      *
-     * @param requests an array of fired sinon requests
-     * @param url the expected url of the request
-     * @param body the expected body of the request
-     * @param requestIndex the expected index of the request in the
-     *     array (higher indices occur later).  Defaults to
-     *     requests.length - 1.
+     * @param {object} requests an array of fired sinon requests
+     * @param {string} url the expected url of the request
+     * @param {string} body the expected body of the request
      */
-    expectPostRequest = function(requests, url, body, requestIndex) {
-        var request;
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        request = requests[requestIndex];
+    expectPostRequest = function(requests, url, body) {
+        var request = currentRequest(requests);
+        expect(request.readyState).toEqual(XHR_READY_STATES.OPENED);
         expect(request.url).toEqual(url);
         expect(request.method).toEqual('POST');
         expect(_.difference(request.requestBody.split('&'), body.split('&'))).toEqual([]);
     };
 
     /**
+     * Verify that the HTTP request was marked as reset, and then skip it.
+     *
+     * Note: this is typically used when code has explicitly canceled a request
+     * after it has been sent. A good example is when a user chooses to cancel
+     * a slow running search.
+
+     * @param {object} requests an array of fired sinon requests
+     */
+    skipResetRequest = function(requests) {
+        var request = currentRequest(requests);
+        expect(request.readyState).toEqual(XHR_READY_STATES.UNSENT);
+        requests.currentIndex++;
+    };
+
+    /**
+     * Respond to a server request with a set of options:
+     *
+     *   - `statusCode`: the status code to be returned (defaults to 200)
+     *   - `contentType`: the content type of the response (defaults to 'application/json')
+     *   - `body`: the body of the response (if JSON, it will be converted to a string)
+     *
+     * @param {object} requests an array of fired sinon requests
+     * @param {object} options the options to provide to the response
+     */
+    respond = function(requests, options) {
+        var request = currentRequest(requests),
+            statusCode = options.statusCode || 200,
+            contentType = options.contentType || 'application/json',
+            body = options.body || '';
+        request.respond(statusCode,
+            {'Content-Type': contentType},
+            contentType === 'application/json' ? JSON.stringify(body || {}) : body
+        );
+        requests.currentIndex++;
+    };
+
+    /**
      * Respond to a request with JSON.
      *
-     * @param requests an array of fired sinon requests
-     * @param jsonResponse an object to be serialized to the response
-     * @param requestIndex the expected index of the request in the
-     *     array (higher indices occur later).  Defaults to
-     *     requests.length - 1.
+     * @param {object} requests an array of fired sinon requests
+     * @param {object} body an object to be serialized to the response
      */
-    respondWithJson = function(requests, jsonResponse, requestIndex) {
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        requests[requestIndex].respond(200,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify(jsonResponse));
+    respondWithJson = function(requests, body) {
+        respond(requests, {
+            body: body
+        });
     };
 
     /**
      * Respond to a request with an error status code and a JSON
      * payload.
      *
-     * @param requests an array of fired sinon requests
-     * @param statusCode the HTTP status code of the response
+     * @param {object} requests an array of fired sinon requests
+     * @param {int} statusCode the HTTP status code of the response
      *     (defaults to 500)
-     * @param jsonResponse an object to be serialized to the response
-     * @param requestIndex the expected index of the request in the
-     *     array (higher indices occur later).  Defaults to
-     *     requests.length - 1.
+     * @param {object} body an object to be serialized to the response
      */
-    respondWithError = function(requests, statusCode, jsonResponse, requestIndex) {
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        if (_.isUndefined(statusCode)) {
-            statusCode = 500;
-        }
-        if (_.isUndefined(jsonResponse)) {
-            jsonResponse = {};
-        }
-        requests[requestIndex].respond(statusCode,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify(jsonResponse)
-        );
+    respondWithError = function(requests, statusCode, body) {
+        respond(requests, {
+            statusCode: statusCode || 500,
+            body: body
+        });
     };
 
     /**
      * Respond to a request with an error status code.
      *
-     * @param requests an array of fired sinon requests
-     * @param statusCode the HTTP status code of the response
+     * @param {object} requests an array of fired sinon requests
+     * @param {int} statusCode the HTTP status code of the response
      *     (defaults to 500)
-     * @param textResponse the response body as a string
-     * @param requestIndex the expected index of the request in the
-     *     array (higher indices occur later).  Defaults to
-     *     requests.length - 1.
+     * @param {object} body the response body as a string
      */
-    respondWithTextError = function(requests, statusCode, textResponse, requestIndex) {
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        if (_.isUndefined(statusCode)) {
-            statusCode = 500;
-        }
-        if (_.isUndefined(textResponse)) {
-            textResponse = '';
-        }
-        requests[requestIndex].respond(statusCode,
-            { 'Content-Type': 'text/plain' },
-            textResponse
-        );
+    respondWithTextError = function(requests, statusCode, body) {
+        respond(requests, {
+            statusCode: statusCode || 500,
+            contentType: 'text/plain',
+            body: body
+        });
     };
 
     /**
      * Respond to a request with an HTTP 204.
      *
-     * @param requests an array of fired sinon requests
-     * @param requestIndex the expected index of the request in the
-     *     array (higher indices occur later).  Defaults to
-     *     requests.length - 1.
+     * @param {object} requests an array of fired sinon requests
      */
-    respondWithNoContent = function(requests, requestIndex) {
-        if (_.isUndefined(requestIndex)) {
-            requestIndex = requests.length - 1;
-        }
-        requests[requestIndex].respond(204,
-            { 'Content-Type': 'application/json' });
+    respondWithNoContent = function(requests) {
+        respond(requests, {
+            statusCode: 204
+        });
     };
 
     return {
+        server: fakeServer,
         requests: fakeRequests,
+        withFakeRequests: withFakeRequests,
+        currentRequest: currentRequest,
         expectRequest: expectRequest,
+        expectNoRequests: expectNoRequests,
         expectJsonRequest: expectJsonRequest,
         expectPostRequest: expectPostRequest,
         expectRequestURL: expectRequestURL,
+        skipResetRequest: skipResetRequest,
+        respond: respond,
         respondWithJson: respondWithJson,
         respondWithError: respondWithError,
         respondWithTextError: respondWithTextError,


### PR DESCRIPTION
## Description

I've updated the AjaxHelpers class to adopt all the changes that have been made in edx-platform. My goal is to be able to then use the UI Toolkit's version in platform, and thus be able to remove the duplicated copy.

The one challenge I had is that ``AjaxHelpers.requests`` had been converted into a wrapper function that simplified its usage. To avoid having to change every caller in platform, I renamed the UI Toolkit version to be ``AjaxHelpers.withFakeRequests``.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers

- [x] @bjacobel 
- [ ] @dan-f 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
