### PR TITLE
Add task to publish API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ To generate this documentation, run the following command:
 To upload a preview of the documentation to S3:
         
         $ gulp preview
+
+To update the hosted documentation:
+        
+        $ gulp doc-publish

--- a/doc/CNAME
+++ b/doc/CNAME
@@ -1,0 +1,1 @@
+ui-toolkit.edx.org

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,8 +1,3 @@
-var dest = './doc/public',
-    src = './pattern-library',
-    siteDir = './_site',
-    docDir = './doc';
-
 module.exports = {
     documentation: {
         testing: {
@@ -28,7 +23,7 @@ module.exports = {
         },
         browserSync: {
             server: {
-                baseDir: siteDir
+                baseDir: './_site'
             },
             ui: {
                 port: 5000,
@@ -44,6 +39,9 @@ module.exports = {
         ],
         static: [
             './doc/static/**/*'
-        ]
+        ],
+        gitHubPages: {
+            files: './_site/**/*'
+        }
     }
 };

--- a/gulp/tasks/doc.js
+++ b/gulp/tasks/doc.js
@@ -16,6 +16,7 @@ var gulp = require('gulp'),
     generateDoc = require('../utils/generate-doc'),
     rename = require('gulp-rename'),
     webpack = require('webpack-stream'),
+    ghPages = require('gulp-gh-pages'),
     renameAsMarkdown,
     generateDocFor;
 
@@ -38,11 +39,18 @@ generateDocFor = function(options) {
 
 gulp.task('doc', function(callback) {
     runSequence(
+        'doc-build',
+        'doc-serve',
+        callback
+    );
+});
+
+gulp.task('doc-build', function(callback) {
+    runSequence(
         ['doc-testing', 'doc-utils', 'doc-views'],
         'copy-pattern-library',
         'webpack',
         'jekyll-build',
-        'doc-serve',
         callback
     );
 });
@@ -103,4 +111,9 @@ gulp.task('jekyll-build', function(done) {
 
 gulp.task('jekyll-rebuild', ['jekyll-build'], function() {
     browserSync.reload();
+});
+
+gulp.task('doc-publish', ['doc-build'], function() {
+    return gulp.src(config.gitHubPages.files)
+        .pipe(ghPages());
 });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "extract-text-webpack-plugin": "~1.0.1",
     "gulp": "~3.9.1",
     "gulp-coveralls": "~0.1.4",
+    "gulp-gh-pages": "~0.5.4",
     "gulp-jscs": "~3.0.2",
     "gulp-jshint": "~2.0.0",
     "gulp-karma": "~0.0.5",


### PR DESCRIPTION
## Description

[FEDX-146](https://openedx.atlassian.net/browse/FEDX-146)

This change uses the library [gulp-gh-pages](https://github.com/shinnn/gulp-gh-pages) to publish the UI Toolkit API documentation to GitHub Pages. This works by cloning the contents of the ``_site`` directory into the gh-pages branch of the UI Toolkit.

I've also updated the release process wiki to describe this new step: https://openedx.atlassian.net/wiki/display/FEDX/UI+Toolkit+release+process

You can see the finished result: http://ui-toolkit.edx.org/

## Post-review
- [x] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @bjacobel 
- [x] @AlasdairSwan 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

We'll also automatically suggest reviewers for this PR based on the code it touches.