### PR TITLE
Minor cleanups to the API documentation

### DIFF
--- a/doc/_includes/collection-page-list.html
+++ b/doc/_includes/collection-page-list.html
@@ -2,15 +2,7 @@
     <h2 class="doc-heading doc-nav-title hd-6">{{ include.title }}</h2>
     <ul class="list-unstyled list-patterns">
     {% for collection_page in include.pages %}
-        <li class="item no-indent {% if page.url == collection_page.url %}is-current{% endif %}">
-            {% unless page.url == collection_page.url %}
-                <a class="pattern-title pattern doc-link" href="{{ site.baseurl }}.{{collection_page.url}}">
-            {% endunless %}
-            {{collection_page.title}}
-            {% unless page.url == collection_page.url %}
-                </a>
-            {% endunless %}
-        </li>
+        {% include navigation-item.html title=collection_page.title url=collection_page.url %}
     {% endfor %}
     </ul>
 </nav>

--- a/doc/_includes/footer.html
+++ b/doc/_includes/footer.html
@@ -1,9 +1,12 @@
 <footer class="doc-footer-site">
     <div class="doc-footer-site-copyright">
         <p class="doc-copy copy-micro">
-            &copy; <time datetime="{{ site.time | date_to_xmlschema }}">{{ site.time | date: '%Y' }}</time>, edX Inc.
-            and licensed under a Creative Commons Attribution-ShareAlike 4.0 International License unless
-            otherwise specified.
+            Copyright &copy; <time datetime="{{ site.time | date_to_xmlschema }}">{{ site.time | date: '%Y' }}</time> edX.
+            <br/>
+            <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a>
+            <br/>
+            These works by <a xmlns:cc="http://creativecommons.org/ns#" href="http://open.edx.org" property="cc:attributionName" rel="cc:attributionURL">edX Inc.</a>
+            are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
         </p>
     </div>
 </footer>

--- a/doc/_includes/navigation-item.html
+++ b/doc/_includes/navigation-item.html
@@ -1,0 +1,9 @@
+<li class="item no-indent {% if include.url == page.url %}is-current{% endif %}">
+    {% unless include.url == page.url %}
+        <a class="pattern-title pattern pldoc-link" href="{{ site.baseurl }}.{{include.url}}">
+    {% endunless %}
+    {{ include.title }}
+    {% unless include.url == page.url %}
+        </a>
+    {% endunless %}
+</li>

--- a/doc/_includes/navigation.html
+++ b/doc/_includes/navigation.html
@@ -1,11 +1,7 @@
-<nav class="doc-nav doc-nav-internal" role="navigation" aria-label="{{ include.title }}">
-    <h2 class="doc-heading doc-nav-title hd-6">{{ site.data.edx-ui-toolkit.name }}</h2>
+<nav class="doc-nav doc-nav-internal" role="navigation" aria-label="{{ site.title }}">
+    <h2 class="doc-heading doc-nav-title hd-6">{{ site.title }}</h2>
     <ul class="list-unstyled list-patterns">
-        <li class="item no-indent">
-            <a class="doc-link" href="{{ site.baseurl }}">
-            Introduction
-            </a>
-        </li>
+        {% include navigation-item.html title="Introduction" url="/" %}
     </ul>
 </nav>
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -12,4 +12,6 @@ The edX UI Toolkit is a JavaScript library for building edX web applications. It
 The toolkit is an open source library that is hosted on [GitHub]({{ site.data.edx-ui-toolkit.url_github }}),
 and that can be installed as an [npm package](https://www.npmjs.com/package/edx-ui-toolkit).
 
+[![edX Pattern Library](https://nodei.co/npm/edx-ui-toolkit.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/edx-ui-toolkit/)
+
 You can read more on the [edX Front End Development wiki](https://openedx.atlassian.net/wiki/display/FEDX/).


### PR DESCRIPTION
## Description

I've made a few clean ups to the UI Toolkit API documentation based upon the work I did in the Pattern Library doc:
 - updated the footer based upon the new design from @lamagnifica (see https://github.com/edx/edx-ui-toolkit/blob/master/doc/_includes/footer.html)
 - fixed a bug where the "Introduction" link didn't highlight appropriately
 - added the NPM version banner to the introduction page

I've created a preview site here: http://ux-test.edx.org/andya/api-doc-refinements/

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
TODO: In this section, tag specific reviewers you know will want to have a look at this PR. You can use the checklist below for organization:

- [x] @bjacobel 
- [ ] @lamagnifica 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

We'll also automatically suggest reviewers for this PR based on the code it touches.
