### PR TITLE
Improve spacing around header

### DIFF
--- a/doc/static/sass/_layouts.scss
+++ b/doc/static/sass/_layouts.scss
@@ -4,6 +4,11 @@
     @extend %grid-wrapper;
 }
 
+.doc-header-site {
+    @extend %grid-container;
+    padding-top: spacing-vertical(x-small);
+}
+
 .doc-header-site-title {
     padding: 0 spacing-vertical(small);
     margin-bottom: 0;


### PR DESCRIPTION
## Description

I noticed before giving the demo that the edX logo was jammed at the top of the page. I borrowed the styling from the Pattern Library.

Compare: http://ux-test.edx.org/andya/more-minor-tweaks/
with: http://ui-toolkit.edx.org/

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @bjacobel

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
