### PR TITLE
Add a doc build to the default gulp task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 sudo: false
 
 node_js:
-    - "4.1"
+    - 4
 
 before_install:
     - export CHROME_BIN=chromium-browser
@@ -11,9 +11,11 @@ before_install:
     - sh -e /etc/init.d/xvfb start
 
 install:
+    - rvm install 2.2.2
     - npm install
+    - bundle install
 
-script: gulp test --ci
+script: gulp default --ci
 
 branches:
     only:

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,5 +1,7 @@
 module.exports = {
     documentation: {
+        targetDir: './_site',
+        previewTargetDir: './_preview_site',
         testing: {
             sources: [
                 './src/js/utils/spec-helpers/*.js'

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var gulp    = require('gulp'),
+    config  = require('../config'),
+    del     = require('del');
+
+gulp.task('clean', function() {
+    return del([
+        // Remove the Jekyll site
+        config.documentation.targetDir,
+
+        // Remove the preview site
+        config.documentation.previewTargetDir,
+
+        // Remove the JSDoc generated markdown
+        config.documentation.testing.output,
+        config.documentation.utilities.output,
+        config.documentation.views.output
+    ]);
+});

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,5 +1,10 @@
-(function() {
-    'use strict';
-    var gulp = require('gulp');
-    gulp.task('default', ['test', 'lint', 'jscs', 'coverage']);
-}());
+'use strict';
+
+var gulp = require('gulp');
+
+gulp.task('default', [
+    'lint',
+    'jscs',
+    'test',
+    'doc-build'
+]);

--- a/gulp/tasks/doc.js
+++ b/gulp/tasks/doc.js
@@ -104,9 +104,8 @@ gulp.task('webpack-rebuild', function(callback) {
     );
 });
 
-gulp.task('jekyll-build', function(done) {
-    return childProcess.spawn('jekyll', ['build'], {stdio: 'inherit'})
-        .on('close', done);
+gulp.task('jekyll-build', function() {
+    childProcess.execSync('jekyll build');
 });
 
 gulp.task('jekyll-rebuild', ['jekyll-build'], function() {

--- a/gulp/tasks/doc.js
+++ b/gulp/tasks/doc.js
@@ -112,7 +112,7 @@ gulp.task('jekyll-rebuild', ['jekyll-build'], function() {
     browserSync.reload();
 });
 
-gulp.task('doc-publish', ['doc-build'], function() {
+gulp.task('doc-publish', ['clean', 'doc-build'], function() {
     return gulp.src(config.gitHubPages.files)
         .pipe(ghPages());
 });

--- a/gulp/tasks/preview.js
+++ b/gulp/tasks/preview.js
@@ -13,8 +13,7 @@
 
 'use strict';
 
-var path = require('path'),
-    gulp = require('gulp'),
+var gulp = require('gulp'),
     runSequence = require('run-sequence'),
     childProcess = require('child_process'),
     webpack = require('webpack-stream'),

--- a/gulp/tasks/preview.js
+++ b/gulp/tasks/preview.js
@@ -18,12 +18,14 @@ var gulp = require('gulp'),
     childProcess = require('child_process'),
     webpack = require('webpack-stream'),
     gitUtils = require('../utils/git-utils'),
+    config  = require('../config').documentation,
     previewConfigFile = '_tmp_preview_config.yml',
-    previewSiteDir = '_preview_site',
     previewDomain = process.env.S3_PREVIEW_DOMAIN;
 
 gulp.task('preview', function(callback) {
     runSequence(
+        'clean',
+        'doc-build',
         'jekyll-build-preview',
         'preview-webpack',
         'upload-preview',
@@ -43,7 +45,7 @@ gulp.task('jekyll-build-preview', function() {
     // Generate the preview version of the site
     console.log('Generating preview for branch ' + branch);
     childProcess.execSync(
-        'jekyll build --config _config.yml,' + previewConfigFile + ' --destination ' + previewSiteDir
+        'jekyll build --config _config.yml,' + previewConfigFile + ' --destination ' + config.previewTargetDir
     );
 
     // Remove the configuration file since it is no longer needed
@@ -51,7 +53,7 @@ gulp.task('jekyll-build-preview', function() {
 });
 
 gulp.task('preview-webpack', function() {
-    var outputPath =  previewSiteDir + '/public/',
+    var outputPath =  config.previewTargetDir + '/public/',
         branch = gitUtils.currentBranch();
     process.env.SITE_ROOT = '/' + branch + '/';
     return gulp.src('')
@@ -63,7 +65,7 @@ gulp.task('upload-preview', function() {
     var branch = gitUtils.currentBranch();
     if (previewDomain) {
         childProcess.execSync(
-            'aws s3 sync ' + previewSiteDir + ' s3://' + previewDomain + '/' + branch
+            'aws s3 sync ' + config.previewTargetDir + ' s3://' + previewDomain + '/' + branch
         );
         console.log('Preview site ready at http://' + previewDomain + '/' + branch);
     } else {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "browser-sync": "~2.11.2",
     "css-loader": "~0.23.1",
+    "del": "~2.2.0",
     "edx-pattern-library": "~0.12.5",
     "extract-text-webpack-plugin": "~1.0.1",
     "gulp": "~3.9.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "backbone": "~1.2.3",
     "backbone.paginator": "~2.0.3",
-    "bower": "~1.3.12",
     "jquery": "~2.2.0",
     "requirejs": "~2.1.22",
     "requirejs-text": "~2.0.12",
@@ -30,7 +29,7 @@
   "devDependencies": {
     "browser-sync": "~2.11.2",
     "css-loader": "~0.23.1",
-    "edx-pattern-library": "~0.12.1",
+    "edx-pattern-library": "~0.12.5",
     "extract-text-webpack-plugin": "~1.0.1",
     "gulp": "~3.9.1",
     "gulp-coveralls": "~0.1.4",
@@ -58,7 +57,7 @@
     "karma-requirejs": "~0.2.2",
     "karma-sinon": "~1.0.3",
     "karma-spec-reporter": "~0.0.24",
-    "node-sass": "~3.4.2",
+    "node-sass": "~3.7.0",
     "phantomjs-prebuilt": "~2.1.7",
     "require-dir": "latest",
     "requirejs-plugins": "~1.0.2",


### PR DESCRIPTION
## Description

Add the doc build to the default gulp task, and change Travis to run the default task rather than just the tests. This is to ensure that all the gulp tasks are still working.

## Post-review
- [x] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @bjacobel 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
