### PR TITLE
update parseState to update all state properties

### DIFF
--- a/src/js/pagination/paging-collection.js
+++ b/src/js/pagination/paging-collection.js
@@ -46,8 +46,10 @@
             queryParams: {
                 currentPage: 'page',
                 pageSize: 'page_size',
+                totalRecords: 'count',
+                totalPages: 'num_pages',
                 sortKey: 'order_by',
-                order: 'sort_order',
+                order: 'sort_order'
             },
 
             constructor: function (models, options) {
@@ -77,15 +79,6 @@
                 return PageableCollection.prototype.parse.call(this, modifiedResponse, options);
             },
 
-            /* jshint unused:false */
-            /**
-             * Parses state from the server response.  Used only by
-             * backbone.paginator.
-             */
-            parseState: function (response, queryParams, state, options) {
-                return {totalRecords: response[0].count, totalPages: response[0].num_pages};
-            },
-
             /**
              * Returns the current page number as if numbering starts on
              * page one, regardless of the indexing of the underlying
@@ -95,6 +88,34 @@
              */
             getPageNumber: function () {
                 return this.state.currentPage + (1 - this.state.firstPage);
+            },
+
+            /**
+             * Returns the total pages of the collection based on
+             * total records and page size
+             *
+             * @returns {integer} Total number of pages.
+             */
+            getTotalPages: function () {
+                return this.state.totalPages;
+            },
+
+            /**
+             * Returns the total number of records the collection has
+             *
+             * @returns {integer} Total number of records.
+             */
+            getTotalRecords: function () {
+                return this.state.totalRecords;
+            },
+
+            /**
+             * Returns the number of records per page
+             *
+             * @returns {integer} Number of records per page.
+             */
+            getPageSize: function () {
+                return this.state.pageSize;
             },
 
             /**

--- a/src/js/pagination/specs/paging-collection-spec.js
+++ b/src/js/pagination/specs/paging-collection-spec.js
@@ -65,6 +65,53 @@ define(['jquery',
                 expect(newCollection.queryParams.currentPage).toBe('page');
             });
 
+            SpecHelpers.withData({
+                'correctly sets state when parse is set to true after instantiating': [null, null],
+                'correctly sets state when parse is set to true in set method': ['set', {
+                    page: 3,
+                    numPages: 5,
+                    pageSize: 10
+                }],
+                'correctly sets state when parse is set to true in reset method': ['reset', {
+                    page: 3,
+                    numPages: 3,
+                    pageSize: 15
+                }]
+            }, function (method, expectedState) {
+                var newCollection;
+                newCollection = new PagingCollection({
+                    count: 43,
+                    page: 2,
+                    num_pages: 6,
+                    page_size: 8,
+                    results: []
+                }, {parse: true});
+
+                expect(newCollection.getPageSize()).toBe(8);
+                expect(newCollection.getPageNumber()).toBe(2);
+                expect(newCollection.getTotalRecords()).toBe(43);
+                expect(newCollection.getTotalPages()).toBe(6);
+
+                if (method) {
+                    newCollection[method]({
+                        count: 43,
+                        page: expectedState.page,
+                        num_pages: expectedState.numPages,
+                        page_size: expectedState.pageSize,
+                        sort_order: -1,
+                        order_by: 'testcol',
+                        results: []
+                    }, {parse: true});
+
+                    expect(newCollection.getPageSize()).toBe(expectedState.pageSize);
+                    expect(newCollection.getPageNumber()).toBe(expectedState.page);
+                    expect(newCollection.getTotalPages()).toBe(expectedState.numPages);
+                    expect(newCollection.getTotalRecords()).toBe(43);
+                    expect(newCollection.state.sortKey).toBe('testcol');
+                    expect(newCollection.state.order).toBe(-1);
+                }
+            });
+
             it('can register sortable fields', function () {
                 collection.registerSortableField('test_field', 'Test Field');
                 expect('test_field' in collection.sortableFields).toBe(true);


### PR DESCRIPTION
## Description
These changes add the ability to set the state from response without fetching the collection from server. Before these changes collection state would only update after the response has come from server. So if we set the response during instantiating or in `set` and `reset` methods of collection, the state wouldn't update other than the `totalRecords` and `totalPages`.

These changes has overridden two more query parameters value `totalRecords` and `totalPages` and removed the overridden `parseState` method in favor of `PageableCollection`'s more complete version of the method that ensures that all passed response gets evaluated and state is updated accordingly. For example if now we can set the current page during instantiation like following.

```javascript
var collection = new PagingCollection({
    count: 10,
    page: 2,
    page_size: 3,
   num_pages: 4,
    results: []
}, {parse: true}); 
```

These changes also include some getters to get state. I thought it would be better to not touch the state directly, ideally state shouldn't be changed directly.


## Testing Checklist
- [x] Write unit tests for all new features.

## Post-review
- [x] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @dan-f
- [x] @andy-armstrong 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
