### PR TITLE
[PagingCollection] Do not send unnecessary query parameters in request in

### DIFF
--- a/src/js/pagination/paging-collection.js
+++ b/src/js/pagination/paging-collection.js
@@ -48,6 +48,8 @@
                 pageSize: 'page_size',
                 sortKey: 'order_by',
                 order: 'sort_order',
+                totalPages: null,
+                totalRecords: null
             },
 
             constructor: function (models, options) {

--- a/src/js/pagination/specs/paging-collection-spec.js
+++ b/src/js/pagination/specs/paging-collection-spec.js
@@ -45,6 +45,13 @@ define(['jquery',
                 });
             };
 
+            var assertNotInQueryParams = function (requests, params) {
+                var urlParams = getUrlParams(requests[requests.length - 1]);
+                params.forEach(function (param) {
+                    expect(urlParams[param]).toBe(undefined);
+                });
+            };
+
             beforeEach(function () {
                 collection = new PagingCollection([], {state: {pageSize: 10}});
                 collection.url = '/test';
@@ -86,6 +93,28 @@ define(['jquery',
                     assertQueryParams(requests, {'sort_order': 'asc'});
                     expect(collection.state.sortKey).toBe('test_field');
                     expect(collection.sortDisplayName()).toBe('Test Field');
+                }
+            ));
+
+            it('doesn\'t send unnecessary parameters in request (total pages, total records)', AjaxHelpers.requests(
+                function (requests) {
+                    // After first fetch the state is updated with returned response
+                    collection.fetch();
+                    server.respond(requests);
+                    collection.fetch();
+                    assertNotInQueryParams(requests, ['total_entries', 'total_pages']);
+
+                    var newCollection = new PagingCollection([], {
+                        state: {
+                            pageSize: 10,
+                            totalPages: 10,
+                            totalRecords: 100
+                        }
+                    });
+
+                    newCollection.url = '/test';
+                    newCollection.fetch();
+                    assertNotInQueryParams(requests, ['total_entries', 'total_pages']);
                 }
             ));
 


### PR DESCRIPTION
## Description
These changes remove extra query parameters, defined in queryParams object's totalRecords and totalPages keys. Before these changes there were extra params going in the request like `total_entries=10&total_pages=5`. These params were being sent only when state object's `totalRecords` and `totalPages` were set. So on first request these params wouldn't go but they would on subsequent requests when state is set by the server response. These params have no meaning for server and are extraneous.

## Testing Checklist
- [ ] Write unit tests for all new features.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [ ] @dan-f 
- [ ] @andy-armstrong 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

