### PR TITLE
Add breadcrumbs JavaScript in preparation for new Pattern Library component

### DIFF
--- a/src/js/breadcrumbs/breadcrumbs-model.js
+++ b/src/js/breadcrumbs/breadcrumbs-model.js
@@ -1,0 +1,40 @@
+/**
+ * A Backbone model that works with the BreadcrumbsView to provide breadcrumb navigation
+ *
+ * Here's what initializing a BreadcrumbsModel looks like:
+ *
+ *~~~ javascript
+ * var model = new BreadcrumbsModel({
+ *     breadcrumbs: [
+ *         {
+ *             url: '/',
+ *             title: 'Item List'
+ *         },
+ *         {
+ *             url: '/details/1',
+ *             title: 'Item Details'
+ *         }
+ *     ],
+ *     label: 'Demo Page'
+ * });
+ *~~~
+ * @module BreadcrumbsModel
+ */
+;(function (define) {
+    'use strict';
+
+    define(['backbone'], function (Backbone) {
+        var BreadcrumbsModel = Backbone.Model.extend({
+            defaults: {
+                'breadcrumbs': null,
+                'label': ''
+            }
+        });
+
+        return BreadcrumbsModel;
+    });
+}).call(
+    this,
+    // Use the default 'define' function if available, else use 'RequireJS.define'
+    typeof define === 'function' && define.amd ? define : RequireJS.define
+);

--- a/src/js/breadcrumbs/breadcrumbs-view.js
+++ b/src/js/breadcrumbs/breadcrumbs-view.js
@@ -1,0 +1,46 @@
+/**
+ * A Backbone view that renders breadcrumbs-type tiered navigation.
+ *
+ * Initialize the view by passing in the following attributes:
+ *
+ *~~~ javascript
+ * var view = new DropdownMenuView({
+ *     el: $('selector for element that will contain breadcrumbs'),
+ *     model: new BreadcrumbsModel({
+ *         breadcrumbs: [{url: '/', title: 'Overview'}]
+ *     }),
+ *     events: {
+ *         'click nav.breadcrumbs a.nav-item': function (event) {
+ *             event.preventDefault();
+ *             window.location = $(event.currentTarget).attr('href');
+ *         }
+ *     }
+ * });
+ *~~~
+ * @module BreadcrumbsView
+ */
+;(function (define) {
+    'use strict';
+    define(['backbone', 'edx-ui-toolkit/js/utils/html-utils', 'text!./breadcrumbs.underscore'],
+        function (Backbone, HtmlUtils, breadcrumbsTemplate) {
+            var BreadcrumbsView = Backbone.View.extend({
+                initialize: function (options) {
+                    this.template = HtmlUtils.template(breadcrumbsTemplate);
+                    this.listenTo(this.model, 'change', this.render);
+                    this.render();
+                },
+
+                render: function () {
+                    var json = this.model.attributes;
+                    HtmlUtils.setHtml(this.$el, this.template(json));
+                    return this;
+                }
+            });
+
+            return BreadcrumbsView;
+        });
+}).call(
+    this,
+    // Use the default 'define' function if available, else use 'RequireJS.define'
+    typeof define === 'function' && define.amd ? define : RequireJS.define
+);

--- a/src/js/breadcrumbs/breadcrumbs.underscore
+++ b/src/js/breadcrumbs/breadcrumbs.underscore
@@ -1,0 +1,12 @@
+<div class="sr-is-focusable" tabindex="-1"></div>
+<% if (breadcrumbs !== null && breadcrumbs.length > 0) { %>
+    <nav class="breadcrumbs list-inline" aria-label="<%- label %>">
+        <% _.each(breadcrumbs.slice(0, -1), function (breadcrumb) { %>
+            <span class="nav-item">
+                <a href="<%- breadcrumb.url %>"><%- breadcrumb.title %></a>
+                <span class="fa fa-angle-right" aria-hidden="true"></span>
+            </span>
+        <% }) %>
+        <span class="nav-item"><%- breadcrumbs[breadcrumbs.length - 1].title %></span>
+    </nav>
+<% } %>

--- a/src/js/breadcrumbs/specs/breadcrumbs-spec.js
+++ b/src/js/breadcrumbs/specs/breadcrumbs-spec.js
@@ -1,0 +1,67 @@
+(function (define) {
+    'use strict';
+
+    define([
+            'jquery',
+            '../../utils/html-utils.js',
+            '../../utils/spec-helpers/spec-helpers.js',
+            '../breadcrumbs-view.js',
+            '../breadcrumbs-model.js'
+           ],
+           function($, HtmlUtils, SpecHelpers, BreadcrumbsView, BreadcrumbsModel) {
+
+               describe('BreadcrumbsView', function () {
+                   var model, view;
+
+                   beforeEach(function () {
+                       model = new BreadcrumbsModel();
+                       view = new BreadcrumbsView({
+                           model: model
+                       });
+                   });
+
+                   it('does not show breadcrumbs by default', function () {
+                       expect(view.$el.html()).not.toContain('<nav class="breadcrumbs">');
+                   });
+
+                   SpecHelpers.withData({
+                       'with no breadcrumbs': [[]],
+                       'with one breadcrumb': [[
+                           {url: 'url1', title: 'Crumb 1'}
+                       ]],
+                       'with two breadcrumbs': [[
+                           {url: 'url1', title: 'Crumb 1'},
+                           {url: 'url2', title: 'Crumb 2'}
+                       ]],
+                       'with unicode breadcrumbs': [[
+                           {url: '', title: '☃'}
+                       ]],
+                       'with breadcrumbs containing HTML': [[
+                           {url: '', title: '<h1>crumb!</h1>'}
+                       ]]
+                   }, function (breadcrumbs) {
+                       var crumbs, linkCrumbs, lastCrumb;
+
+                       model.set('breadcrumbs', breadcrumbs);
+
+                       crumbs = view.$('.nav-item');
+                       linkCrumbs = crumbs.slice(0, -1);
+
+                       expect(crumbs.length).toBe(breadcrumbs.length);
+
+                       linkCrumbs.each(function (index, el) {
+                           expect($('a', el).attr('href')).toEqual(breadcrumbs[index].url);
+                           expect($('a', el).text()).toEqual(breadcrumbs[index].title);
+                       });
+
+                       if (crumbs.length > 0) {
+                           // The last crumb is not a link
+                           lastCrumb = crumbs.length - 1;
+                           expect(crumbs.eq(lastCrumb).text()).toEqual(breadcrumbs[lastCrumb].title);
+                           expect(crumbs.eq(lastCrumb).is('a')).toBeFalsy();
+                       }
+                   });
+               });
+           }
+          );
+}).call(this, define || RequireJS.define);


### PR DESCRIPTION
Refs [TNL-4599](https://openedx.atlassian.net/browse/TNL-4599)

Adds backbone view, model and test for a breadcrumb component soon to be added to the UXPL.

[UXPL PR is here.](https://github.com/edx/ux-pattern-library/pull/334)

## Testing Checklist
- [x] Write unit tests for all new features.
- [x] Write accessibility (a11y) tests for all new UI.
- [x] Manually test responsive behavior.

## Non-testing Checklist
- [x] Consider any documentation your change might need, and which users will be affected by this change.
- [x] Consult with the Pattern Library team if adding a new component.

## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @andy-armstrong 
- [ ] @dianakhuang 
- [x] @clrux (a11y review)

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

We'll also automatically suggest reviewers for this PR based on the code it touches.
