### PR TITLE
Add some configuration for mention-bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,7 +1,8 @@
 {
   "userBlacklist": [
     "dan-f",
-    "talbs"
+    "talbs",
+    "peter-fogg"
   ],
   "skipAlreadyMentionedPR": true
 }

--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,7 @@
+{
+  "userBlacklist": [
+    "dan-f",
+    "talbs"
+  ],
+  "skipAlreadyMentionedPR": true
+}


### PR DESCRIPTION
@dan-f asked me if we could find a way to keep @mention-bot to not ping him on PRs for code review anymore. I've also seen it add Brian to some reviews so I added him to the exclude list as well.

Also added option `skipAlreadyMentionedPR`, which will prevent @-msging people who have already been explicitly listed for review.

- [ ] @andy-armstrong 