### PR TITLE
Remove uneccessary DOM element from breadcrumb template

### DIFF
--- a/src/js/breadcrumbs/breadcrumbs.underscore
+++ b/src/js/breadcrumbs/breadcrumbs.underscore
@@ -1,4 +1,3 @@
-<div class="sr-is-focusable" tabindex="-1"></div>
 <% if (breadcrumbs !== null && breadcrumbs.length > 0) { %>
     <nav class="breadcrumbs list-inline" aria-label="<%- label %>">
         <% _.each(breadcrumbs.slice(0, -1), function (breadcrumb) { %>


### PR DESCRIPTION
## Description

Chris (via Alasdair's code review comment) alerted me that this is DOM node not actually necessary for the breadcrumbs to correctly manage focus.

## Testing Checklist
N/A

## Non-testing Checklist
N/A

## Post-review
- [x] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers
- [x] @clrux 
- [x] @AlasdairSwan 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

We'll also automatically suggest reviewers for this PR based on the code it touches.

