### PR TITLE
Update to newest eslint-config-edx. Remove IIFEs in Node code.

### DIFF
--- a/gulp/.eslintrc.json
+++ b/gulp/.eslintrc.json
@@ -1,4 +1,9 @@
 {
+    "parserOptions": {
+        "ecmaFeatures": {
+          "globalReturn": true
+        }
+    },
     "rules": {
         "no-console": "off"
     }

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
     documentation: {
         targetDir: './_site',

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,21 +1,20 @@
+'use strict';
+
 var gulp = require('gulp'),
     config = require('../config'),
     del = require('del');
 
-(function() {
-    'use strict';
-    gulp.task('clean', function() {
-        return del([
-            // Remove the Jekyll site
-            config.documentation.targetDir,
+gulp.task('clean', function() {
+    return del([
+        // Remove the Jekyll site
+        config.documentation.targetDir,
 
-            // Remove the preview site
-            config.documentation.previewTargetDir,
+        // Remove the preview site
+        config.documentation.previewTargetDir,
 
-            // Remove the JSDoc generated markdown
-            config.documentation.testing.output,
-            config.documentation.utilities.output,
-            config.documentation.views.output
-        ]);
-    });
-}());
+        // Remove the JSDoc generated markdown
+        config.documentation.testing.output,
+        config.documentation.utilities.output,
+        config.documentation.views.output
+    ]);
+});

--- a/gulp/tasks/coverage.js
+++ b/gulp/tasks/coverage.js
@@ -1,11 +1,9 @@
+'use strict';
+
 var gulp = require('gulp'),
     coveralls = require('gulp-coveralls');
 
-(function() {
-    'use strict';
-
-    gulp.task('coverage', function() {
-        return gulp.src('coverage/**/lcov.info')
-            .pipe(coveralls());
-    });
-}());
+gulp.task('coverage', function() {
+    return gulp.src('coverage/**/lcov.info')
+        .pipe(coveralls());
+});

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,11 +1,9 @@
+'use strict';
+
 var gulp = require('gulp');
 
-(function() {
-    'use strict';
-
-    gulp.task('default', [
-        'lint',
-        'test',
-        'doc-build'
-    ]);
-}());
+gulp.task('default', [
+    'lint',
+    'test',
+    'doc-build'
+]);

--- a/gulp/tasks/doc.js
+++ b/gulp/tasks/doc.js
@@ -6,6 +6,8 @@
  *  - doc-serve: serves up the API documentation through browser sync
  */
 
+'use strict';
+
 var gulp = require('gulp'),
     childProcess = require('child_process'),
     browserSync = require('browser-sync'),
@@ -15,108 +17,104 @@ var gulp = require('gulp'),
     rename = require('gulp-rename'),
     webpack = require('webpack-stream'),
     ghPages = require('gulp-gh-pages'),
-    webpackConfig = require('../../webpack.config.js');
+    webpackConfig = require('../../webpack.config.js'),
+    renameAsMarkdown,
+    generateDocFor;
 
-(function() {
-    'use strict';
+renameAsMarkdown = function(path) {
+    var renamedPath = path;
+    renamedPath.extname = '.md';
+    return renamedPath;
+};
 
-    var renameAsMarkdown, generateDocFor;
+generateDocFor = function(options) {
+    var i, sources,
+        sourceLength = options.sources.length;
+    for (i = 0; i < sourceLength; i++) {
+        sources = options.sources[i];
+        console.log('Generating documentation for ' + sources);
+        gulp.src(sources, {buffer: false})
+            .pipe(generateDoc(options.viewClass))
+            .pipe(rename(renameAsMarkdown))
+            .pipe(gulp.dest(options.output));
+    }
+};
 
-    renameAsMarkdown = function(path) {
-        var renamedPath = path;
-        renamedPath.extname = '.md';
-        return renamedPath;
-    };
+gulp.task('doc', function(callback) {
+    runSequence(
+        'doc-build',
+        'doc-serve',
+        callback
+    );
+});
 
-    generateDocFor = function(options) {
-        var i, sources,
-            sourceLength = options.sources.length;
-        for (i = 0; i < sourceLength; i++) {
-            sources = options.sources[i];
-            console.log('Generating documentation for ' + sources);
-            gulp.src(sources, {buffer: false})
-                .pipe(generateDoc(options.viewClass))
-                .pipe(rename(renameAsMarkdown))
-                .pipe(gulp.dest(options.output));
-        }
-    };
+gulp.task('doc-build', function(callback) {
+    runSequence(
+        ['doc-testing', 'doc-utils', 'doc-views'],
+        'copy-pattern-library',
+        'webpack',
+        'jekyll-build',
+        callback
+    );
+});
 
-    gulp.task('doc', function(callback) {
-        runSequence(
-            'doc-build',
-            'doc-serve',
-            callback
-        );
-    });
+gulp.task('doc-serve', function() {
+    // Run browserSync to serve the doc site
+    browserSync(config.browserSync);
 
-    gulp.task('doc-build', function(callback) {
-        runSequence(
-            ['doc-testing', 'doc-utils', 'doc-views'],
-            'copy-pattern-library',
-            'webpack',
-            'jekyll-build',
-            callback
-        );
-    });
+    // Watch the UI Toolkit's source code
+    gulp.watch(config.testing.sources, ['doc-testing', 'webpack-rebuild']);
+    gulp.watch(config.utilities.sources, ['doc-utils', 'webpack-rebuild']);
+    gulp.watch(config.views.sources, ['doc-views', 'webpack-rebuild']);
 
-    gulp.task('doc-serve', function() {
-        // Run browserSync to serve the doc site
-        browserSync(config.browserSync);
+    // Watch the doc site's static assets
+    gulp.watch(config.static, ['webpack-rebuild']);
 
-        // Watch the UI Toolkit's source code
-        gulp.watch(config.testing.sources, ['doc-testing', 'webpack-rebuild']);
-        gulp.watch(config.utilities.sources, ['doc-utils', 'webpack-rebuild']);
-        gulp.watch(config.views.sources, ['doc-views', 'webpack-rebuild']);
+    // Watch the doc site's templates
+    gulp.watch(config.templates, ['jekyll-rebuild']);
+});
 
-        // Watch the doc site's static assets
-        gulp.watch(config.static, ['webpack-rebuild']);
+gulp.task('doc-testing', function() {
+    generateDocFor(config.testing);
+});
 
-        // Watch the doc site's templates
-        gulp.watch(config.templates, ['jekyll-rebuild']);
-    });
+gulp.task('doc-utils', function() {
+    generateDocFor(config.utilities);
+});
 
-    gulp.task('doc-testing', function() {
-        generateDocFor(config.testing);
-    });
+gulp.task('doc-views', function() {
+    generateDocFor(config.views);
+});
 
-    gulp.task('doc-utils', function() {
-        generateDocFor(config.utilities);
-    });
+gulp.task('copy-pattern-library', function() {
+    gulp.src(['./node_modules/edx-pattern-library/pattern-library/**/*'])
+        .pipe(gulp.dest('doc/public/edx-pattern-library'));
+});
 
-    gulp.task('doc-views', function() {
-        generateDocFor(config.views);
-    });
+gulp.task('webpack', function() {
+    return gulp.src('')
+        .pipe(webpack(webpackConfig))
+        .pipe(gulp.dest(webpackConfig.output.path))
+        .pipe(browserSync.stream());
+});
 
-    gulp.task('copy-pattern-library', function() {
-        gulp.src(['./node_modules/edx-pattern-library/pattern-library/**/*'])
-            .pipe(gulp.dest('doc/public/edx-pattern-library'));
-    });
+gulp.task('webpack-rebuild', function(callback) {
+    runSequence(
+        'webpack',
+        'jekyll-rebuild',
+        callback
+    );
+});
 
-    gulp.task('webpack', function() {
-        return gulp.src('')
-            .pipe(webpack(webpackConfig))
-            .pipe(gulp.dest(webpackConfig.output.path))
-            .pipe(browserSync.stream());
-    });
+gulp.task('jekyll-build', function() {
+    childProcess.execSync('jekyll build');
+});
 
-    gulp.task('webpack-rebuild', function(callback) {
-        runSequence(
-            'webpack',
-            'jekyll-rebuild',
-            callback
-        );
-    });
+gulp.task('jekyll-rebuild', ['jekyll-build'], function() {
+    browserSync.reload();
+});
 
-    gulp.task('jekyll-build', function() {
-        childProcess.execSync('jekyll build');
-    });
-
-    gulp.task('jekyll-rebuild', ['jekyll-build'], function() {
-        browserSync.reload();
-    });
-
-    gulp.task('doc-publish', ['clean', 'doc-build'], function() {
-        return gulp.src(config.gitHubPages.files)
-            .pipe(ghPages());
-    });
-}());
+gulp.task('doc-publish', ['clean', 'doc-build'], function() {
+    return gulp.src(config.gitHubPages.files)
+        .pipe(ghPages());
+});

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -1,8 +1,6 @@
+'use strict';
+
 var gulp = require('gulp'),
     shell = require('gulp-shell');
 
-(function() {
-    'use strict';
-
-    gulp.task('lint', shell.task('eslint .'));
-}());
+gulp.task('lint', shell.task('eslint .'));

--- a/gulp/tasks/preview.js
+++ b/gulp/tasks/preview.js
@@ -11,85 +11,82 @@
  * used to host your S3 preview.
  */
 
+'use strict';
+
 var gulp = require('gulp'),
     runSequence = require('run-sequence'),
     childProcess = require('child_process'),
     webpack = require('webpack-stream'),
     gitUtils = require('../utils/git-utils'),
     config = require('../config').documentation,
-    webpackConfig = require('../../webpack.config.js');
+    webpackConfig = require('../../webpack.config.js'),
+    previewConfigFile = '_tmp_preview_config.yml',
+    previewDomain = process.env.S3_PREVIEW_DOMAIN;
 
-(function() {
-    'use strict';
+gulp.task('preview', function(callback) {
+    runSequence(
+        'clean',
+        'doc-build',
+        'jekyll-build-preview',
+        'preview-webpack',
+        'upload-preview',
+        'show-preview',
+        callback
+    );
+});
 
-    var previewConfigFile = '_tmp_preview_config.yml',
-        previewDomain = process.env.S3_PREVIEW_DOMAIN;
+gulp.task('jekyll-build-preview', function() {
+    var branch = gitUtils.currentBranch(),
+        previewBaseUrl = '/' + branch + '/';
+    // Create a temporary Jekyll configuration file which specifies the base URL for the preview site
+    childProcess.execSync(
+        'echo \'baseurl: ' + previewBaseUrl + '\' > ' + previewConfigFile
+    );
 
-    gulp.task('preview', function(callback) {
-        runSequence(
-            'clean',
-            'doc-build',
-            'jekyll-build-preview',
-            'preview-webpack',
-            'upload-preview',
-            'show-preview',
-            callback
-        );
-    });
+    // Generate the preview version of the site
+    console.log('Generating preview for branch ' + branch);
+    childProcess.execSync(
+        'jekyll build --config _config.yml,' + previewConfigFile + ' --destination ' + config.previewTargetDir
+    );
 
-    gulp.task('jekyll-build-preview', function() {
-        var branch = gitUtils.currentBranch(),
-            previewBaseUrl = '/' + branch + '/';
-        // Create a temporary Jekyll configuration file which specifies the base URL for the preview site
+    // Remove the configuration file since it is no longer needed
+    childProcess.execSync('rm ' + previewConfigFile);
+});
+
+gulp.task('preview-webpack', function() {
+    var outputPath = config.previewTargetDir + '/public/',
+        branch = gitUtils.currentBranch();
+    process.env.SITE_ROOT = '/' + branch + '/';
+    return gulp.src('')
+        .pipe(webpack(webpackConfig))
+        .pipe(gulp.dest(outputPath));
+});
+
+gulp.task('upload-preview', function() {
+    var branch = gitUtils.currentBranch();
+    if (previewDomain) {
         childProcess.execSync(
-            'echo \'baseurl: ' + previewBaseUrl + '\' > ' + previewConfigFile
+            'aws s3 sync ' + config.previewTargetDir + ' s3://' + previewDomain + '/' + branch
         );
-
-        // Generate the preview version of the site
-        console.log('Generating preview for branch ' + branch);
-        childProcess.execSync(
-            'jekyll build --config _config.yml,' + previewConfigFile + ' --destination ' + config.previewTargetDir
+        console.log('Preview site ready at http://' + previewDomain + '/' + branch);
+    } else {
+        console.log(
+            'No preview domain specified. Please export environment variable S3_PREVIEW_DOMAIN and try again.'
         );
+    }
+});
 
-        // Remove the configuration file since it is no longer needed
-        childProcess.execSync('rm ' + previewConfigFile);
-    });
+gulp.task('remove-preview', function() {
+    var branch = gitUtils.currentBranch();
+    childProcess.execSync(
+        'aws s3 rm --recursive  s3://' + previewDomain + '/' + branch
+    );
+    console.log('Removed preview for branch ' + branch);
+});
 
-    gulp.task('preview-webpack', function() {
-        var outputPath = config.previewTargetDir + '/public/',
-            branch = gitUtils.currentBranch();
-        process.env.SITE_ROOT = '/' + branch + '/';
-        return gulp.src('')
-            .pipe(webpack(webpackConfig))
-            .pipe(gulp.dest(outputPath));
-    });
-
-    gulp.task('upload-preview', function() {
-        var branch = gitUtils.currentBranch();
-        if (previewDomain) {
-            childProcess.execSync(
-                'aws s3 sync ' + config.previewTargetDir + ' s3://' + previewDomain + '/' + branch
-            );
-            console.log('Preview site ready at http://' + previewDomain + '/' + branch);
-        } else {
-            console.log(
-                'No preview domain specified. Please export environment variable S3_PREVIEW_DOMAIN and try again.'
-            );
-        }
-    });
-
-    gulp.task('remove-preview', function() {
-        var branch = gitUtils.currentBranch();
-        childProcess.execSync(
-            'aws s3 rm --recursive  s3://' + previewDomain + '/' + branch
-        );
-        console.log('Removed preview for branch ' + branch);
-    });
-
-    gulp.task('show-preview', function() {
-        var branch = gitUtils.currentBranch();
-        childProcess.execSync(
-            'open http://' + previewDomain + '/' + branch
-        );
-    });
-}());
+gulp.task('show-preview', function() {
+    var branch = gitUtils.currentBranch();
+    childProcess.execSync(
+        'open http://' + previewDomain + '/' + branch
+    );
+});

--- a/gulp/tasks/test-debug.js
+++ b/gulp/tasks/test-debug.js
@@ -1,15 +1,12 @@
+'use strict';
+
 var gulp = require('gulp'),
     karma = require('karma'),
-    path = require('path');
+    path = require('path'),
+    configFile = 'test/karma.debug.conf.js';
 
-(function() {
-    'use strict';
-
-    var configFile = 'test/karma.debug.conf.js';
-
-    gulp.task('test-debug', function(callback) {
-        new karma.Server({
-            configFile: path.resolve(configFile)
-        }, callback).start();
-    });
-}());
+gulp.task('test-debug', function(callback) {
+    new karma.Server({
+        configFile: path.resolve(configFile)
+    }, callback).start();
+});

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,20 +1,17 @@
+'use strict';
+
 var gulp = require('gulp'),
     karma = require('karma'),
-    path = require('path');
+    path = require('path'),
+    configFile;
 
-(function() {
-    'use strict';
-
-    var configFile;
-
-    gulp.task('test', function(callback) {
-        if (process.argv.indexOf('--ci') !== -1) {
-            configFile = 'test/karma.ci.conf.js';
-        } else {
-            configFile = 'test/karma.conf.js';
-        }
-        new karma.Server({
-            configFile: path.resolve(configFile)
-        }, callback).start();
-    });
-}());
+gulp.task('test', function(callback) {
+    if (process.argv.indexOf('--ci') !== -1) {
+        configFile = 'test/karma.ci.conf.js';
+    } else {
+        configFile = 'test/karma.conf.js';
+    }
+    new karma.Server({
+        configFile: path.resolve(configFile)
+    }, callback).start();
+});

--- a/gulp/utils/generate-doc.js
+++ b/gulp/utils/generate-doc.js
@@ -1,55 +1,52 @@
+'use strict';
+
 var jsdox = require('jsdox'),
     path = require('path'),
     through = require('through2'),
     GulpUtil = require('gulp-util'),
-    jsdocParser = require('jsdoc3-parser');
+    jsdocParser = require('jsdoc3-parser'),
+    PLUGIN_NAME = 'generate-doc',
+    analyze = jsdox.analyze,
+    generateMD = jsdox.generateMD,
+    jsdoxTemplatesDir = 'node_modules/jsdox/templates';
 
-(function() {
-    'use strict';
+module.exports = function(viewClass) {
+    return through.obj(function(file, enc, next) {
+        var self = this;
+        if (file.isStream()) {
+            jsdocParser(file.history, function(err, result) {
+                var frontMatter, data, markdown, title, relativePath, requirePath, gitHubPath,
+                    fileToPush = file;
+                if (err) {
+                    console.error('Error generating docs for file', file, err);
+                    next(err);
+                } else {
+                    // Generate the front matter
+                    relativePath = path.relative(path.resolve('src'), file.path);
+                    requirePath = 'edx-ui-toolkit/' + relativePath.slice(0, -3);
+                    gitHubPath = 'blob/master/src/' + relativePath;
+                    // title = path.relative(path.resolve('src/js'), file.path).slice(0, -3);
+                    title = path.basename(file.path, '.js');
+                    frontMatter = '---\n' +
+                        'title: ' + title + '\n' +
+                        'requirePath: ' + requirePath + '\n' +
+                        'githubPath: ' + gitHubPath + '\n' +
+                        'viewClass: ' + viewClass + '\n' +
+                        '---\n\n';
 
-    var PLUGIN_NAME = 'generate-doc',
-        analyze = jsdox.analyze,
-        generateMD = jsdox.generateMD,
-        jsdoxTemplatesDir = 'node_modules/jsdox/templates';
+                    // Generate the markdown
+                    data = analyze(result, {});
+                    markdown = generateMD(data, jsdoxTemplatesDir);
 
-    module.exports = function(viewClass) {
-        return through.obj(function(file, enc, next) {
-            var self = this;
-            if (file.isStream()) {
-                jsdocParser(file.history, function(err, result) {
-                    var frontMatter, data, markdown, title, relativePath, requirePath, gitHubPath,
-                        fileToPush = file;
-                    if (err) {
-                        console.error('Error generating docs for file', file, err);
-                        next(err);
-                    } else {
-                        // Generate the front matter
-                        relativePath = path.relative(path.resolve('src'), file.path);
-                        requirePath = 'edx-ui-toolkit/' + relativePath.slice(0, -3);
-                        gitHubPath = 'blob/master/src/' + relativePath;
-                        // title = path.relative(path.resolve('src/js'), file.path).slice(0, -3);
-                        title = path.basename(file.path, '.js');
-                        frontMatter = '---\n' +
-                            'title: ' + title + '\n' +
-                            'requirePath: ' + requirePath + '\n' +
-                            'githubPath: ' + gitHubPath + '\n' +
-                            'viewClass: ' + viewClass + '\n' +
-                            '---\n\n';
-
-                        // Generate the markdown
-                        data = analyze(result, {});
-                        markdown = generateMD(data, jsdoxTemplatesDir);
-
-                        // set the result to the front matter followed by the markdown
-                        fileToPush.contents = new Buffer(frontMatter + markdown);
-                    }
-                    self.push(fileToPush);
-                    next();
-                });
-            } else {
-                this.emit('error', new GulpUtil.PluginError(PLUGIN_NAME, 'Non-streams not supported!'));
+                    // set the result to the front matter followed by the markdown
+                    fileToPush.contents = new Buffer(frontMatter + markdown);
+                }
+                self.push(fileToPush);
                 next();
-            }
-        });
-    };
-}());
+            });
+        } else {
+            this.emit('error', new GulpUtil.PluginError(PLUGIN_NAME, 'Non-streams not supported!'));
+            next();
+        }
+    });
+};

--- a/gulp/utils/git-utils.js
+++ b/gulp/utils/git-utils.js
@@ -1,17 +1,14 @@
-var childProcess = require('child_process');
+'use strict';
 
-(function() {
-    'use strict';
+var childProcess = require('child_process'),
+    gitBranchCommand = 'git rev-parse --abbrev-ref HEAD';
 
-    var gitBranchCommand = 'git rev-parse --abbrev-ref HEAD';
-
-    module.exports = {
-        /**
-         * Returns the current Git branch for the current directory.
-         */
-        currentBranch: function() {
-            var branch = childProcess.execSync(gitBranchCommand);
-            return branch.toString().trim();
-        }
-    };
-}());
+module.exports = {
+    /**
+     * Returns the current Git branch for the current directory.
+     */
+    currentBranch: function() {
+        var branch = childProcess.execSync(gitBranchCommand);
+        return branch.toString().trim();
+    }
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "del": "~2.2.0",
     "edx-pattern-library": "~0.12.5",
     "eslint": "~2.13.1",
-    "eslint-config-edx": "~1.0.0",
+    "eslint-config-edx": "~1.2.1",
     "extract-text-webpack-plugin": "~1.0.1",
     "gulp": "~3.9.1",
     "gulp-coveralls": "~0.1.4",

--- a/src/js/dropdown-menu/dropdown-menu-view.js
+++ b/src/js/dropdown-menu/dropdown-menu-view.js
@@ -49,7 +49,7 @@
                 events: {
                     'click .js-dropdown-button': 'clickOpenDropdown',
                     'click a': 'analyticsLinkClick',
-                    'keydown': 'viewKeypress'
+                    keydown: 'viewKeypress'
                 },
 
                 dropdownButton: '.js-dropdown-button',

--- a/test/require-config.js
+++ b/test/require-config.js
@@ -6,26 +6,26 @@ require.config({
     baseUrl: '/base',
     waitSeconds: 60,
     paths: {
-        'backbone': 'node_modules/backbone/backbone',
+        backbone: 'node_modules/backbone/backbone',
         'backbone.paginator': 'node_modules/backbone.paginator/lib/backbone.paginator',
-        'jquery': 'node_modules/jquery/dist/jquery',
+        jquery: 'node_modules/jquery/dist/jquery',
         'jquery.simulate': 'test/jquery.simulate',
-        'text': 'node_modules/requirejs-text/text',
-        'underscore': 'node_modules/underscore/underscore',
-        'sinon': 'node_modules/sinon/lib/sinon',
+        text: 'node_modules/requirejs-text/text',
+        underscore: 'node_modules/underscore/underscore',
+        sinon: 'node_modules/sinon/lib/sinon',
 
         // URI and its dependencies
-        'URI': 'node_modules/urijs/src/URI',
-        'IPv6': 'node_modules/urijs/src/IPv6',
-        'punycode': 'node_modules/urijs/src/punycode',
-        'SecondLevelDomains': 'node_modules/urijs/src/SecondLevelDomains'
+        URI: 'node_modules/urijs/src/URI',
+        IPv6: 'node_modules/urijs/src/IPv6',
+        punycode: 'node_modules/urijs/src/punycode',
+        SecondLevelDomains: 'node_modules/urijs/src/SecondLevelDomains'
     },
     wrapShim: true,
     shim: {
-        'jquery': {
+        jquery: {
             exports: '$'
         },
-        'backbone': {
+        backbone: {
             deps: ['underscore', 'jquery'],
             exports: 'Backbone',
             init: function(_, $) {
@@ -39,7 +39,7 @@ require.config({
             deps: ['jquery'],
             exports: ['$.simulate']
         },
-        'underscore': {
+        underscore: {
             exports: '_'
         },
         'edx-ui-toolkit/js/utils/global-loader': {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,11 +23,11 @@ var path = require('path'),
         modulesDirectories: ['node_modules'],
         resolve: {
             alias: {
-                'afontgarde': 'edx-pattern-library/js/afontgarde',
-                'modernizr': 'edx-pattern-library/js/modernizr-custom',
+                afontgarde: 'edx-pattern-library/js/afontgarde',
+                modernizr: 'edx-pattern-library/js/modernizr-custom',
                 'edx-pattern-library': patternLibraryPath,
                 'edx-ui-toolkit': path.resolve(__dirname, 'src'),
-                'doc': path.resolve(__dirname, 'doc/static')
+                doc: path.resolve(__dirname, 'doc/static')
             }
         },
         module: {


### PR DESCRIPTION
Update to the version of eslint-config-edx that contains fixes to 'use strict'; rule. Node code doesn't need to be wrapped in IIFEs and should 'use strict'; at global scope.


(This undoes all the wrapping of this code I thought I needed to do a few weeks ago....)


- [ ] @andy-armstrong 
- [x] @alisan617 

