### PR TITLE
Add dependencies that are used by consumers as peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,11 @@
     "through2": "~2.0.0",
     "webpack": "~1.12.14",
     "webpack-stream": "~3.2.0"
+  },
+  "peerDependencies": {
+    "backbone.paginator": "~2.0.3",
+    "moment": "^2.15.1",
+    "moment-timezone": "~0.5.5",
+    "sinon": "1.17.3 || >1.17.4"
   }
 }


### PR DESCRIPTION
## Description

These four libraries (Sinon, Moment, Moment-tz, and Backbone paginator) are used both by the Toolkit internally, but also by consumers of the UITK as native dependencies.

The way we approach this right now in edx-platform is to install `edx-ui-toolkit`, then copy the version of, say, backbone.paginator, out of the `node_modules/edx-ui-toolkit/node_modules/backbone.paginator` folder into `common/static/js/vendor`. [See assets.py in edx-platform.](https://github.com/edx/edx-platform/blob/master/pavelib/assets.py#L52) 

This approach works in NPM 1, but as we upgrade to NPM 3 it will break, because NPM 3 installs all dependencies at the top level of the folder structure (and thus the `node_modules/edx-ui-toolkit/node_modules/backbone.paginator` will no longer exist).

As we upgrade NPM for edx-platform, we'll be handling this by explicitly adding these four libraries to edx-platform's dependencies, so in both NPM 1 and NPM 3 they'll exist at the top level of the `node_modules` folder and we can copy them from there.

Adding these dependencies to the `peerDependencies` list of the UI Toolkit isn't specifically necessary, but it's a hint to consumers that you need them installed alongside the UI Toolkit (and shouldn't rely on them coming along "inside" the UI Toolkit).

The behavior changes that result from adding these dependencies to peerDependencies are:
- *in NPM 1*:
  - *If you already have these libs in the dependencies of a UI Toolkit consumer*: No change.
  - *if you don't have these libs as explicit deps of a UI Toolkit consumer*: They'll be installed at the top level of the `node_modules` folder for you when you `npm install`, *in addition to* the place they're already installed (`node_modules/edx-ui-toolkit/node_modules/lib`)
- *in NPM 3+* *:
  - *If you already have these libs in the dependencies of a UI Toolkit consumer*: No change.
  - *if you don't have these libs as explicit deps of a UI Toolkit consumer*: `npm install` will throw a warning saying you're missing peerDependencies, and you'll have to explicitly add them to the consumer's dependencies.

I'll follow this up with a similar PR to the pattern library - although it may not be needed, I think @alisan617 already added Font Awesome as a peerdep and that's the only thing like this over there.

## Reviewers
- [ ] @andy-armstrong 
- [x] @alisan617 

FYI @AlasdairSwan @dsjen

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

We'll also automatically suggest reviewers for this PR based on the code it touches.

*and Yarn 🌚