### PR TITLE
Delete .mention-bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,8 +1,0 @@
-{
-  "userBlacklist": [
-    "dan-f",
-    "talbs",
-    "peter-fogg"
-  ],
-  "skipAlreadyMentionedPR": true
-}


### PR DESCRIPTION
We don't need this config file now that we've killed off mentionbot.