### PR TITLE
[FEDX-365] Add AJAX spec helper functions for getting specific request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.4 (2017-06-29)
+* Add AJAX spec helper functions which get the last request of a specific URL.
+
+- - -
+
 ## 1.5.3 (2017-04-21)
 * Upgrade eslint and add new eslint configs (eslint-config-edx, eslint-config-edx-es5)
 * Fix resulting linter errors

--- a/src/js/utils/specs/ajax-helpers-spec.js
+++ b/src/js/utils/specs/ajax-helpers-spec.js
@@ -9,6 +9,7 @@ define(
 
         describe('AjaxHelpers', function() {
             var testUrl = 'https://example.com',
+                testUrl2 = 'https://example2.com',
                 testData = {foo: 'bar', fizz: 'buzz'},
                 testQuerystring = $.param(testData);
 
@@ -53,6 +54,30 @@ define(
                         });
                         AjaxHelpers.expectRequest(requests, 'POST', testUrl, 'foobar');
                     }));
+                });
+
+                describe('expectLastRequestWithURL', function() {
+                    it('verifies the last request of the specified url', AjaxHelpers.withFakeRequests(
+                        function(requests) {
+                            $.ajax(testUrl);
+                            $.ajax(testUrl2);
+                            AjaxHelpers.expectLastRequestWithURL(requests, 'GET', testUrl, undefined);
+                        }
+                    ));
+
+                    it('verifies a more complex request of the last specified url', AjaxHelpers.withFakeRequests(
+                        function(requests) {
+                            $.ajax(testUrl, {
+                                method: 'POST',
+                                data: 'foobar'
+                            });
+                            $.ajax(testUrl2, {
+                                method: 'POST',
+                                data: 'foobar'
+                            });
+                            AjaxHelpers.expectLastRequestWithURL(requests, 'POST', testUrl, 'foobar');
+                        }
+                    ));
                 });
 
                 describe('expectNoRequests', function() {


### PR DESCRIPTION
## Description

[FEDX-365](https://openedx.atlassian.net/browse/FEDX-365)

Some more spec helpers to help with tests I'm working on in an edx-platform PR. Basically, I needed (at some point) to get the last request that used a specific URL. This should add functionality to do that.

## Testing Checklist
- [x] Write unit tests for all new features.

## Non-testing Checklist
- [ ] Needs documentation to be regenerated.

## Post-review
- [x] Squash commits into discrete sets of changes with descriptive commit messages.

## Reviewers

- [ ] @andy-armstrong (take your time)

If you've been tagged for review, please check your corresponding box once you've given the :+1:.