### PR TITLE
SE-2176 Update doc comments for accuracy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: node_js
 
 sudo: true

--- a/src/js/utils/html-utils.js
+++ b/src/js/utils/html-utils.js
@@ -93,7 +93,7 @@
          * );
          *~~~
          *
-         * returns:
+         * returns an HtmlSnippet object whose .toString() method returns:
          *
          *~~~ javascript
          * 'You are enrolling in <span class="course-title">Rock &amp; Roll 101</span>'
@@ -108,6 +108,26 @@
          *     gettext('You are enrolling in {spanStart}{courseName}{spanEnd}'),
          *     ...
          * );
+         *~~~
+         *
+         * Since escaping is done by default, this is safe to use for rendering untrusted
+         * input within html. For example:
+         *
+         *~~~ javascript
+         * HtmlUtils.interpolateHtml(
+         *     'User said {emStart}{comment}{emEnd}',
+         *     {
+         *         emStart: HtmlUtils.HTML('<em>'),
+         *         comment: '<script>alert("test");</script>',
+         *         emEnd: HtmlUtils.HTML('</em>'),
+         *     }
+         * );
+         *~~~
+         *
+         * returns an HtmlSnippet object whose .toString() method returns:
+         *
+         *~~~ javascript
+         * 'User said <em>&lt;script&gt;alert(&quot;test&quot;);&lt;/script&gt;</em>'
          *~~~
          *
          * @param {string} formatString The string to be interpolated.

--- a/src/js/utils/specs/string-utils-spec.js
+++ b/src/js/utils/specs/string-utils-spec.js
@@ -26,6 +26,10 @@ define(
                     'does not interpolate additional curly braces': [
                         'Hello, {name}. Here is a { followed by a }', {name: 'Andy'},
                         'Hello, Andy. Here is a { followed by a }'
+                    ],
+                    'does not escape html': [
+                        '<b>Hello</b>, {name}', {name: '<script>alert("boom");</script>'},
+                        '<b>Hello</b>, <script>alert("boom");</script>'
                     ]
                 }, function(template, options, expectedString) {
                     var result = StringUtils.interpolate(template, options);

--- a/src/js/utils/string-utils.js
+++ b/src/js/utils/string-utils.js
@@ -16,20 +16,18 @@
          * indicated via curly braces, e.g. 'Hello {name}'. These tokens are
          * replaced by the parameter value of the same name.
          *
-         * Parameter values will be rendered using their toString methods and then
-         * HTML-escaped. The only exception is that instances of the class HTML
-         * are rendered without escaping as their contract declares that they are
-         * already valid HTML.
+         * Parameter values will be rendered using their toString methods.
+         * **NO** HTML escaping or sanitizing of any form is performed.
+         * If HTML escaping is required (for example, if user supplied input is
+         * being interpolated), use HtmlUtils.interpolateHtml().
          *
          * Example:
          *
          *~~~ javascript
-         * HtmlUtils.interpolate(
-         *     'You are enrolling in {spanStart}{courseName}{spanEnd}',
+         * StringUtils.interpolate(
+         *     'You are enrolling in {courseName}',
          *     {
          *         courseName: 'Rock & Roll 101',
-         *         spanStart: HtmlUtils.HTML('<span class="course-title">'),
-         *         spanEnd: HtmlUtils.HTML('</span>')
          *     }
          * );
          *~~~
@@ -37,7 +35,7 @@
          * returns:
          *
          *~~~ javascript
-         * 'You are enrolling in <span class="course-title">Rock &amp; Roll 101</span>'
+         * 'You are enrolling in Rock & Roll 101'
          *~~~
          *
          * Note: typically the formatString will need to be internationalized, in which
@@ -45,8 +43,8 @@
          * this would look like:
          *
          *~~~ javascript
-         * HtmlUtils.interpolate(
-         *     gettext('You are enrolling in {spanStart}{courseName}{spanEnd}'),
+         * StringUtils.interpolate(
+         *     gettext('You are enrolling in {courseName}'),
          *     ...
          * );
          *~~~


### PR DESCRIPTION
Currently there are discrepancies between the official docs, the code, and the doc comments here. These were found while investigating https://github.com/edx/edx-platform/pull/23039#discussion_r417670046

This PR does:
- provide example of html escaping for the interpolateHtml method
- fix misleading comments about escaping for StringUtils.interpolate (it
  does not in fact escape anything)
- update interpolate examples for accuracy and to better represent functionality
- add a test to show that html is not escaped

**Jira tickets**: [OSPR-4435](https://openedx.atlassian.net/browse/OSPR-4435)

**Test instructions**:

- cross reference the updated doc comments with the code, tests, and [official docs](https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss.html#legacy-javascript-files) to verify accuracy
- verify that tests pass

**Reviewers**:

- [x] @bradenmacdonald 
- [ ] edX reviewers TBD